### PR TITLE
Improve error handling for no-such-object type processing

### DIFF
--- a/lib/backend/etcd.go
+++ b/lib/backend/etcd.go
@@ -137,7 +137,7 @@ func (c *EtcdClient) Delete(k KeyInterface) error {
 	}
 	glog.V(2).Infof("Delete Key: %s\n", key)
 	_, err = c.etcdKeysAPI.Delete(context.Background(), key, etcdDeleteOpts)
-	return convertEtcdError(err, key)
+	return convertEtcdError(err, k)
 }
 
 // Get an entry from the datastore.  This errors if the entry does not exist.
@@ -153,7 +153,7 @@ func (c *EtcdClient) Get(k KeyInterface) (*DatastoreObject, error) {
 	}
 	glog.V(2).Infof("Get Key: %s\n", key)
 	if results, err := c.etcdKeysAPI.Get(context.Background(), key, etcdGetOpts); err != nil {
-		return nil, convertEtcdError(err, key)
+		return nil, convertEtcdError(err, k)
 	} else if object, err := ParseValue(k, []byte(results.Node.Value)); err != nil {
 		return nil, err
 	} else {
@@ -170,7 +170,14 @@ func (c *EtcdClient) List(l ListInterface) ([]*DatastoreObject, error) {
 	key := l.asEtcdKeyRoot()
 	glog.V(2).Infof("List Key: %s\n", key)
 	if results, err := c.etcdKeysAPI.Get(context.Background(), key, etcdListOpts); err != nil {
-		return nil, err
+		err = convertEtcdError(err, nil)
+		// If the root key does not exist - that's fine, return no list entries.
+		switch err.(type) {
+		case common.ErrorResourceDoesNotExist:
+			return []*DatastoreObject{}, nil
+		default:
+			return nil, err
+		}
 	} else {
 		list := filterEtcdList(results.Node, l)
 
@@ -201,7 +208,7 @@ func (c *EtcdClient) set(d *DatastoreObject, options *etcd.SetOptions) (*Datasto
 	glog.V(2).Infof("Options: %v\n", options)
 	result, err := c.etcdKeysAPI.Set(context.Background(), key, value, options)
 	if err != nil {
-		return nil, convertEtcdError(err, key)
+		return nil, convertEtcdError(err, d.Key)
 	}
 
 	// Datastore object will be identical except for the modified index.
@@ -231,7 +238,7 @@ func filterEtcdList(n *etcd.Node, l ListInterface) []*DatastoreObject {
 	return dos
 }
 
-func convertEtcdError(err error, key string) error {
+func convertEtcdError(err error, key KeyInterface) error {
 	if err == nil {
 		glog.V(2).Info("Comand completed without error")
 		return nil
@@ -242,19 +249,19 @@ func convertEtcdError(err error, key string) error {
 		switch err.(etcd.Error).Code {
 		case etcd.ErrorCodeNodeExist:
 			glog.V(2).Info("Node exists error")
-			return common.ErrorResourceAlreadyExists{Err: err, Name: key}
+			return common.ErrorResourceAlreadyExists{Err: err, Identifier: key}
 		case etcd.ErrorCodeKeyNotFound:
 			glog.V(2).Info("Key not found error")
-			return common.ErrorResourceDoesNotExist{Err: err, Name: key}
+			return common.ErrorResourceDoesNotExist{Err: err, Identifier: key}
 		case etcd.ErrorCodeUnauthorized:
 			glog.V(2).Info("Unauthorized error")
 			return common.ErrorConnectionUnauthorized{Err: err}
 		default:
 			glog.V(2).Infof("Generic etcd error error: %v", err)
-			return common.ErrorDatastoreError{Err: err}
+			return common.ErrorDatastoreError{Err: err, Identifier: key}
 		}
 	default:
 		glog.V(2).Infof("Unhandled error: %v", err)
-		return common.ErrorDatastoreError{Err: err}
+		return common.ErrorDatastoreError{Err: err, Identifier: key}
 	}
 }

--- a/lib/backend/hostendpoint.go
+++ b/lib/backend/hostendpoint.go
@@ -36,8 +36,11 @@ type HostEndpointKey struct {
 }
 
 func (key HostEndpointKey) asEtcdKey() (string, error) {
-	if key.Hostname == "" || key.EndpointID == "" {
-		return "", ErrorInsufficientIdentifiers{}
+	if key.Hostname == "" {
+		return "", ErrorInsufficientIdentifiers{Name: "hostname"}
+	}
+	if key.EndpointID == "" {
+		return "", ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/v1/host/%s/endpoint/%s",
 		key.Hostname, key.EndpointID)
@@ -50,6 +53,10 @@ func (key HostEndpointKey) asEtcdDeleteKey() (string, error) {
 
 func (key HostEndpointKey) valueType() reflect.Type {
 	return typeHostEndpoint
+}
+
+func (key HostEndpointKey) String() string {
+	return fmt.Sprintf("HostEndpoint(hostname=%s, name=%s)", key.Hostname, key.EndpointID)
 }
 
 type HostEndpointListOptions struct {

--- a/lib/backend/policy.go
+++ b/lib/backend/policy.go
@@ -35,8 +35,11 @@ type PolicyKey struct {
 }
 
 func (key PolicyKey) asEtcdKey() (string, error) {
-	if key.Name == "" || key.Tier == "" {
-		return "", common.ErrorInsufficientIdentifiers{}
+	if key.Tier == "" {
+		return "", common.ErrorInsufficientIdentifiers{Name: "tier"}
+	}
+	if key.Name == "" {
+		return "", common.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/v1/policy/tier/%s/policy/%s",
 		key.Tier, key.Name)
@@ -49,6 +52,10 @@ func (key PolicyKey) asEtcdDeleteKey() (string, error) {
 
 func (key PolicyKey) valueType() reflect.Type {
 	return typePolicy
+}
+
+func (key PolicyKey) String() string {
+	return fmt.Sprintf("Policy(tier=%s, name=%s)", key.Tier, key.Name)
 }
 
 type PolicyListOptions struct {

--- a/lib/backend/pool.go
+++ b/lib/backend/pool.go
@@ -36,7 +36,7 @@ type PoolKey struct {
 
 func (key PoolKey) asEtcdKey() (string, error) {
 	if key.CIDR.IP == nil {
-		return "", common.ErrorInsufficientIdentifiers{}
+		return "", common.ErrorInsufficientIdentifiers{Name: "cidr"}
 	}
 	c := strings.Replace(key.CIDR.String(), "/", "-", 1)
 	e := fmt.Sprintf("/calico/v1/ipam/v%d/pool/%s", key.CIDR.Version(), c)
@@ -49,6 +49,10 @@ func (key PoolKey) asEtcdDeleteKey() (string, error) {
 
 func (key PoolKey) valueType() reflect.Type {
 	return typePool
+}
+
+func (key PoolKey) String() string {
+	return fmt.Sprintf("Policy(cidr=%s)", key.CIDR)
 }
 
 type PoolListOptions struct {

--- a/lib/backend/profile.go
+++ b/lib/backend/profile.go
@@ -40,7 +40,7 @@ type ProfileKey struct {
 
 func (key ProfileKey) asEtcdKey() (string, error) {
 	if key.Name == "" {
-		return "", common.ErrorInsufficientIdentifiers{}
+		return "", common.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/v1/policy/profile/%s", key.Name)
 	return e, nil
@@ -52,6 +52,10 @@ func (key ProfileKey) asEtcdDeleteKey() (string, error) {
 
 func (key ProfileKey) valueType() reflect.Type {
 	return typeProfile // FIXME is this required?
+}
+
+func (key ProfileKey) String() string {
+	return fmt.Sprintf("Profile(name=%s)", key.Name)
 }
 
 // ProfileRulesKey implements the KeyInterface for the profile rules

--- a/lib/backend/tier.go
+++ b/lib/backend/tier.go
@@ -40,7 +40,7 @@ func (key TierKey) asEtcdKey() (string, error) {
 
 func (key TierKey) asEtcdDeleteKey() (string, error) {
 	if key.Name == "" {
-		return "", common.ErrorInsufficientIdentifiers{}
+		return "", common.ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	e := fmt.Sprintf("/calico/v1/policy/tier/%s", key.Name)
 	return e, nil
@@ -48,6 +48,10 @@ func (key TierKey) asEtcdDeleteKey() (string, error) {
 
 func (key TierKey) valueType() reflect.Type {
 	return typeTier
+}
+
+func (key TierKey) String() string {
+	return fmt.Sprintf("Tier(name=%s)", key.Name)
 }
 
 type TierListOptions struct {

--- a/lib/backend/workloadendpoint.go
+++ b/lib/backend/workloadendpoint.go
@@ -37,8 +37,17 @@ type WorkloadEndpointKey struct {
 }
 
 func (key WorkloadEndpointKey) asEtcdKey() (string, error) {
-	if key.Hostname == "" || key.OrchestratorID == "" || key.WorkloadID == "" || key.EndpointID == "" {
-		return "", ErrorInsufficientIdentifiers{}
+	if key.Hostname == "" {
+		return "", ErrorInsufficientIdentifiers{Name: "hostname"}
+	}
+	if key.OrchestratorID == "" {
+		return "", ErrorInsufficientIdentifiers{Name: "orchestrator"}
+	}
+	if key.WorkloadID == "" {
+		return "", ErrorInsufficientIdentifiers{Name: "workload"}
+	}
+	if key.EndpointID == "" {
+		return "", ErrorInsufficientIdentifiers{Name: "name"}
 	}
 	return fmt.Sprintf("/calico/v1/host/%s/workload/%s/%s/endpoint/%s",
 		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID), nil
@@ -50,6 +59,11 @@ func (key WorkloadEndpointKey) asEtcdDeleteKey() (string, error) {
 
 func (key WorkloadEndpointKey) valueType() reflect.Type {
 	return reflect.TypeOf(WorkloadEndpoint{})
+}
+
+func (key WorkloadEndpointKey) String() string {
+	return fmt.Sprintf("WorkloadEndpoint(hostname=%s,orchestrator=%s,workload=%s,name=%s)",
+		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID)
 }
 
 type WorkloadEndpointListOptions struct {

--- a/lib/client/ipam_handle.go
+++ b/lib/client/ipam_handle.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+
 	"github.com/tigera/libcalico-go/lib/backend"
 	"github.com/tigera/libcalico-go/lib/common"
 )

--- a/lib/client/policy.go
+++ b/lib/client/policy.go
@@ -15,8 +15,6 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/tigera/libcalico-go/lib/api"
 	"github.com/tigera/libcalico-go/lib/backend"
 	"github.com/tigera/libcalico-go/lib/common"
@@ -59,7 +57,7 @@ func (h *policies) Create(a *api.Policy) (*api.Policy, error) {
 			}
 		}
 	} else if _, err := h.c.Tiers().Get(api.TierMetadata{Name: a.Metadata.Tier}); err != nil {
-		return nil, common.ErrorResourceDoesNotExist{Name: fmt.Sprintf("Tier '%s'", a.Metadata.Tier)}
+		return nil, err
 	}
 
 	return a, h.c.create(*a, h)
@@ -81,7 +79,7 @@ func (h *policies) Apply(a *api.Policy) (*api.Policy, error) {
 			}
 		}
 	} else if _, err := h.c.Tiers().Get(api.TierMetadata{Name: a.Metadata.Tier}); err != nil {
-		return nil, common.ErrorResourceDoesNotExist{Name: fmt.Sprintf("Tier '%s'", a.Metadata.Tier)}
+		return nil, err
 	}
 
 	return a, h.c.apply(*a, h)

--- a/lib/common/errors.go
+++ b/lib/common/errors.go
@@ -14,11 +14,14 @@
 
 package common
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Error indicating a problem connecting to the backend.
 type ErrorDatastoreError struct {
-	Err error
+	Err        error
+	Identifier interface{}
 }
 
 func (e ErrorDatastoreError) Error() string {
@@ -28,23 +31,23 @@ func (e ErrorDatastoreError) Error() string {
 // Error indicating a resource does not exist.  Used when attempting to delete or
 // udpate a non-existent resource.
 type ErrorResourceDoesNotExist struct {
-	Err  error
-	Name string
+	Err        error
+	Identifier interface{}
 }
 
 func (e ErrorResourceDoesNotExist) Error() string {
-	return fmt.Sprintf("resource does not exist with name '%s'", e.Name)
+	return fmt.Sprintf("resource does not exist: %s", e.Identifier)
 }
 
 // Error indicating a resource already exists.  Used when attempting to create a
 // resource that already exists.
 type ErrorResourceAlreadyExists struct {
-	Err  error
-	Name string
+	Err        error
+	Identifier interface{}
 }
 
 func (e ErrorResourceAlreadyExists) Error() string {
-	return fmt.Sprintf("resource already exists with name '%s'", e.Name)
+	return fmt.Sprintf("resource already exists: %s", e.Identifier)
 }
 
 // Error indicating a problem connecting to the backend.
@@ -84,9 +87,12 @@ func (e ErrorValidation) Error() string {
 	}
 }
 
+// TODO:  Useful to know which identifiers are missing.  Need to think about how to
+// distinguish between API/Backend and JSON versions of the field.
 type ErrorInsufficientIdentifiers struct {
+	Name string
 }
 
 func (e ErrorInsufficientIdentifiers) Error() string {
-	return "insufficient identifiers"
+	return fmt.Sprintf("insufficient identifiers, missing '%s'", e.Name)
 }


### PR DESCRIPTION
This PR fixes up the following:

-  List methods return empty slices of objects when the enumeration parent does not exist.
-  Improved error messages for gets/creates etc. when the request is missing some mandatory identifiers (it now includes the name of the identifier)
