### PR TITLE
Add conflict error type

### DIFF
--- a/lib/backend/etcd.go
+++ b/lib/backend/etcd.go
@@ -240,6 +240,9 @@ func convertEtcdError(err error, key string) error {
 	switch err.(type) {
 	case etcd.Error:
 		switch err.(etcd.Error).Code {
+		case etcd.ErrorCodeTestFailed:
+			glog.V(2).Info("Test failed error")
+			return common.ErrorResourceUpdateConflict{Identifier: key}
 		case etcd.ErrorCodeNodeExist:
 			glog.V(2).Info("Node exists error")
 			return common.ErrorResourceAlreadyExists{Err: err, Name: key}

--- a/lib/common/errors.go
+++ b/lib/common/errors.go
@@ -90,3 +90,12 @@ type ErrorInsufficientIdentifiers struct {
 func (e ErrorInsufficientIdentifiers) Error() string {
 	return "insufficient identifiers"
 }
+
+// Error indicating an atomic update attempt that failed due to a update conflict.
+type ErrorResourceUpdateConflict struct {
+	Identifier interface{}
+}
+
+func (e ErrorResourceUpdateConflict) Error() string {
+	return fmt.Sprintf("update conflict: '%s'", e.Identifier)
+}


### PR DESCRIPTION
Add error type indicating resource conflict.

Casey - I think you'll need this for the IPAM work.  It looks like the current IPAM changes defines a cas error type but doesn't use it.

As discussed - I/we also need to fix up the backend API so that the delete processing is also atomic -by ensuing we pass in the revision information as well.  This PR is just to handle the compare error.