### PR TITLE
Add conflict error handling for Delete backend

### DIFF
--- a/lib/backend/client.go
+++ b/lib/backend/client.go
@@ -44,7 +44,7 @@ type DatastoreReadWriteInterface interface {
 	Create(object *DatastoreObject) (*DatastoreObject, error)
 	Update(object *DatastoreObject) (*DatastoreObject, error)
 	Apply(object *DatastoreObject) (*DatastoreObject, error)
-	Delete(key KeyInterface) error
+	Delete(object *DatastoreObject) error
 	Get(key KeyInterface) (*DatastoreObject, error)
 	List(list ListInterface) ([]*DatastoreObject, error)
 }
@@ -90,8 +90,8 @@ func (c *Client) Apply(d *DatastoreObject) (*DatastoreObject, error) {
 }
 
 // Delete an entry in the datastore.  This errors if the entry does not exists.
-func (c *Client) Delete(k KeyInterface) error {
-	return c.rw.Delete(k)
+func (c *Client) Delete(d *DatastoreObject) error {
+	return c.rw.Delete(d)
 }
 
 // Get an entry from the datastore.  This errors if the entry does not exist.

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -103,6 +103,8 @@ type conversionHelper interface {
 	convertMetadataToListInterface(interface{}) (backend.ListInterface, error)
 }
 
+//TODO Plumb through revision data so that front end can do atomic operations.
+
 // Untyped interface for creating an API object.  This is called from the
 // typed interface.  This assumes a 1:1 mapping between the API resource and
 // the backend object.
@@ -145,7 +147,7 @@ func (c *Client) apply(apiObject interface{}, helper conversionHelper) error {
 func (c *Client) delete(metadata interface{}, helper conversionHelper) error {
 	if k, err := helper.convertMetadataToKeyInterface(metadata); err != nil {
 		return err
-	} else if err := c.backend.Delete(k); err != nil {
+	} else if err := c.backend.Delete(&backend.DatastoreObject{Key: k}); err != nil {
 		return err
 	} else {
 		return nil

--- a/lib/client/ipam.go
+++ b/lib/client/ipam.go
@@ -350,7 +350,9 @@ func (c ipams) releaseIPsFromBlock(ips []common.IP, blockCIDR common.IPNet) ([]c
 		var casError error
 		if b.empty() && b.HostAffinity == nil {
 			glog.V(3).Infof("Deleting non-affine block '%s'", b.CIDR.String())
-			casError = c.client.backend.Delete(backend.BlockKey{CIDR: blockCIDR})
+			casError = c.client.backend.Delete(&backend.DatastoreObject{
+				Key: backend.BlockKey{CIDR: blockCIDR},
+			})
 		} else {
 			glog.V(3).Infof("Updating assignments in block '%s'", b.CIDR.String())
 			obj.Object = b.AllocationBlock
@@ -667,7 +669,9 @@ func (c ipams) releaseByHandle(handleID string, blockCIDR common.IPNet) error {
 		}
 
 		if block.empty() && block.HostAffinity == nil {
-			err = c.client.backend.Delete(backend.BlockKey{blockCIDR})
+			err = c.client.backend.Delete(&backend.DatastoreObject{
+				Key: backend.BlockKey{blockCIDR},
+			})
 			if err != nil {
 				if _, ok := err.(common.ErrorResourceDoesNotExist); ok {
 					// Already deleted - carry on.
@@ -751,7 +755,9 @@ func (c ipams) decrementHandle(handleID string, blockCIDR common.IPNet, num int)
 		// Update / Delete as appropriate.
 		if handle.empty() {
 			glog.V(3).Infof("Deleting handle: %s", handleID)
-			err = c.client.backend.Delete(backend.IPAMHandleKey{HandleID: handleID})
+			err = c.client.backend.Delete(&backend.DatastoreObject{
+				Key: backend.IPAMHandleKey{HandleID: handleID},
+			})
 		} else {
 			glog.V(3).Infof("Updating handle: %s", handleID)
 			obj.Object = handle.IPAMHandle

--- a/lib/client/ipam_block_reader_writer.go
+++ b/lib/client/ipam_block_reader_writer.go
@@ -139,7 +139,9 @@ func (rw blockReaderWriter) claimBlockAffinity(subnet common.IPNet, host string,
 			}
 
 			// Some other host beat us to this block.  Cleanup and return error.
-			err = rw.client.backend.Delete(backend.BlockAffinityKey{Host: host, CIDR: b.CIDR})
+			err = rw.client.backend.Delete(&backend.DatastoreObject{
+				Key: backend.BlockAffinityKey{Host: host, CIDR: b.CIDR},
+			})
 			if err != nil {
 				glog.Errorf("Error cleaning up block affinity: %s", err)
 				return err
@@ -173,7 +175,9 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR common.I
 
 		if b.empty() {
 			// If the block is empty, we can delete it.
-			err := rw.client.backend.Delete(backend.BlockKey{CIDR: b.CIDR})
+			err := rw.client.backend.Delete(&backend.DatastoreObject{
+				Key: backend.BlockKey{CIDR: b.CIDR},
+			})
 			if err != nil {
 				if _, ok := err.(common.ErrorResourceDoesNotExist); ok {
 					// Block already deleted.  Carry on.
@@ -205,7 +209,9 @@ func (rw blockReaderWriter) releaseBlockAffinity(host string, blockCIDR common.I
 
 		// We've removed / updated the block, so update the host config
 		// to remove the CIDR.
-		err = rw.client.backend.Delete(backend.BlockAffinityKey{Host: host, CIDR: b.CIDR})
+		err = rw.client.backend.Delete(&backend.DatastoreObject{
+			Key: backend.BlockAffinityKey{Host: host, CIDR: b.CIDR},
+		})
 		if err != nil {
 			if _, ok := err.(common.ErrorResourceDoesNotExist); ok {
 				// Already deleted - carry on.


### PR DESCRIPTION
Casey - this is the other part of the conflict error handling - adding support to the backend Delete method by passing in a DatastoreObject rather than just a Key.