### PR TITLE
Parse may return a pointer - dereference if it does

### DIFF
--- a/lib/backend/etcd.go
+++ b/lib/backend/etcd.go
@@ -160,8 +160,11 @@ func (c *EtcdClient) Get(k KeyInterface) (*DatastoreObject, error) {
 	} else if object, err := ParseValue(k, []byte(results.Node.Value)); err != nil {
 		return nil, err
 	} else {
-		elem := reflect.ValueOf(object).Elem().Interface()
-		return &DatastoreObject{Key: k, Object: elem, Revision: results.Node.ModifiedIndex}, nil
+		if reflect.ValueOf(object).Kind() == reflect.Ptr {
+			// Unwrap any pointers.
+			object = reflect.ValueOf(object).Elem().Interface()
+		}
+		return &DatastoreObject{Key: k, Object: object, Revision: results.Node.ModifiedIndex}, nil
 	}
 }
 


### PR DESCRIPTION
I think this should fix the problem you were hitting invoking Get() - I had a similar issue with the List() command which I had already fixed.

I've shot Shaun a message asking why the ParseValue() only dereferences non-structs, as my preferred approach would be to fix up that - but I'd like his input on that before I change it that way.