### PR TITLE
Use ResourceMetadata interface

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -53,7 +53,7 @@ Options:
 
 	cmd := apply{}
 	results := executeConfigCommand(parsedArgs, cmd)
-	glog.V(2).Infof("results: %v", results)
+	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -55,7 +55,7 @@ Options:
 
 	cmd := create{skipIfExists: parsedArgs["--skip-exists"].(bool)}
 	results := executeConfigCommand(parsedArgs, cmd)
-	glog.V(2).Infof("results: %v", results)
+	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -63,7 +63,7 @@ Options:
 
 	cmd := delete{skipIfNotExists: parsedArgs["--skip-not-exists"].(bool)}
 	results := executeConfigCommand(parsedArgs, cmd)
-	glog.V(2).Infof("results: %v", results)
+	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -62,7 +62,7 @@ Options:
 
 	cmd := get{}
 	results := executeConfigCommand(parsedArgs, cmd)
-	glog.V(2).Infof("results: %v", results)
+	glog.V(2).Infof("results: %+v", results)
 
 	if results.err != nil {
 		fmt.Printf("Error getting resources: %v\n", results.err)

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -56,7 +56,7 @@ Options:
 
 	cmd := replace{}
 	results := executeConfigCommand(parsedArgs, cmd)
-	glog.V(2).Infof("results: %v", results)
+	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
 		fmt.Printf("Error processing input file: %v\n", results.err)

--- a/calicoctl/commands/utils.go
+++ b/calicoctl/commands/utils.go
@@ -33,7 +33,7 @@ import (
 // Create a new CalicoClient using connection information in the specified
 // filename (if it exists), dropping back to environment variables for any
 // parameter not loaded from file.
-func NewClient(cf *string) (*client.Client, error) {
+func newClient(cf *string) (*client.Client, error) {
 	if _, err := os.Stat(*cf); err != nil {
 		cf = nil
 	}
@@ -225,7 +225,7 @@ func executeConfigCommand(args map[string]interface{}, cmd commandInterface) com
 
 	// Load the client config and connect.
 	cf := args["--config"].(string)
-	client, err := NewClient(&cf)
+	client, err := newClient(&cf)
 	if err != nil {
 		return commandResults{err: err}
 	}

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -24,7 +24,7 @@ import (
 	"os"
 
 	"github.com/tigera/libcalico-go/lib/api"
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
@@ -37,7 +37,7 @@ import (
 //	   though they are not strictly resources themselves).
 // 	-  The concrete resource struct for this version
 type resourceHelper struct {
-	typeMetadata TypeMetadata
+	typeMetadata unversioned.TypeMetadata
 	resourceType reflect.Type
 }
 
@@ -45,14 +45,14 @@ func (r resourceHelper) String() string {
 	return fmt.Sprintf("Resource %s, version %s", r.typeMetadata.Kind, r.typeMetadata.APIVersion)
 }
 
-// Store a resourceHelper for each resource TypeMetadata.
-var helpers map[TypeMetadata]resourceHelper
+// Store a resourceHelper for each resource unversioned.TypeMetadata.
+var helpers map[unversioned.TypeMetadata]resourceHelper
 
 // Register all of the available resource types, this includes resource lists as well.
 func init() {
-	helpers = make(map[TypeMetadata]resourceHelper)
+	helpers = make(map[unversioned.TypeMetadata]resourceHelper)
 
-	registerHelper := func(t Resource) {
+	registerHelper := func(t unversioned.Resource) {
 		tmd := t.GetTypeMetadata()
 		rh := resourceHelper{
 			tmd,
@@ -78,7 +78,7 @@ func init() {
 
 // Create a new concrete resource structure based on the type.  If the type is
 // a list, this creates a concrete Resource-List of the required type.
-func newResource(tm TypeMetadata) (Resource, error) {
+func newResource(tm unversioned.TypeMetadata) (unversioned.Resource, error) {
 	rh, ok := helpers[tm]
 	if !ok {
 		return nil, errors.New(fmt.Sprintf("Unknown resource type (%s) and/or version (%s)", tm.Kind, tm.APIVersion))
@@ -91,7 +91,7 @@ func newResource(tm TypeMetadata) (Resource, error) {
 	elem.FieldByName("Kind").SetString(rh.typeMetadata.Kind)
 	elem.FieldByName("APIVersion").SetString(rh.typeMetadata.APIVersion)
 
-	return new.Interface().(Resource), nil
+	return new.Interface().(unversioned.Resource), nil
 }
 
 // Create the resource from the specified byte array encapsulating the resource.
@@ -100,12 +100,12 @@ func newResource(tm TypeMetadata) (Resource, error) {
 //
 // The returned Resource will either be a single resource document or a List of documents.
 // If the file does not contain any valid Resources this function returns an error.
-func createResourcesFromBytes(b []byte) ([]Resource, error) {
+func createResourcesFromBytes(b []byte) ([]unversioned.Resource, error) {
 	// Start by unmarshalling the bytes into a TypeMetadata structure - this will ignore
 	// other fields.
 	var err error
-	tm := TypeMetadata{}
-	tms := []TypeMetadata{}
+	tm := unversioned.TypeMetadata{}
+	tms := []unversioned.TypeMetadata{}
 	if err = yaml.Unmarshal(b, &tm); err == nil {
 		// We processed a metadata, so create a concrete resource struct to unpack
 		// into.
@@ -125,7 +125,7 @@ func createResourcesFromBytes(b []byte) ([]Resource, error) {
 //
 // Return as a slice of Resource interfaces, containing a single element that is
 // the unmarshalled resource.
-func unmarshalResource(tm TypeMetadata, b []byte) ([]Resource, error) {
+func unmarshalResource(tm unversioned.TypeMetadata, b []byte) ([]unversioned.Resource, error) {
 	glog.V(2).Infof("Processing type %s\n", tm.Kind)
 	unpacked, err := newResource(tm)
 	if err != nil {
@@ -143,7 +143,7 @@ func unmarshalResource(tm TypeMetadata, b []byte) ([]Resource, error) {
 
 	glog.V(2).Infof("Unpacked: %+v\n", unpacked)
 
-	return []Resource{unpacked}, nil
+	return []unversioned.Resource{unpacked}, nil
 }
 
 // Unmarshal a bytearray containing a list of resources of the specified types into
@@ -151,9 +151,9 @@ func unmarshalResource(tm TypeMetadata, b []byte) ([]Resource, error) {
 //
 // Return as a slice of Resource interfaces, containing an element that is each of
 // the unmarshalled resources.
-func unmarshalSliceOfResources(tml []TypeMetadata, b []byte) ([]Resource, error) {
+func unmarshalSliceOfResources(tml []unversioned.TypeMetadata, b []byte) ([]unversioned.Resource, error) {
 	glog.V(2).Infof("Processing list of resources\n")
-	unpacked := make([]Resource, len(tml))
+	unpacked := make([]unversioned.Resource, len(tml))
 	for i, tm := range tml {
 		glog.V(2).Infof("  - processing type %s\n", tm.Kind)
 		r, err := newResource(tm)
@@ -187,7 +187,7 @@ func unmarshalSliceOfResources(tml []TypeMetadata, b []byte) ([]Resource, error)
 //
 // The returned Resource will either be a single Resource or a List containing zero or more
 // Resources.  If the file does not contain any valid Resources this function returns an error.
-func CreateResourcesFromFile(f string) ([]Resource, error) {
+func CreateResourcesFromFile(f string) ([]unversioned.Resource, error) {
 
 	// Load the bytes from file or from stdin.
 	var b []byte

--- a/lib/api/unversioned/types.go
+++ b/lib/api/unversioned/types.go
@@ -21,6 +21,7 @@ type Resource interface {
 
 // ---- Type metadata ----
 //
+// All resource and resource lists embed a TypeMetadata as an anonymous field.
 type TypeMetadata struct {
 	Kind       string `json:"kind" validate:"required"`
 	APIVersion string `json:"apiVersion" validate:"required"`
@@ -30,8 +31,17 @@ func (md TypeMetadata) GetTypeMetadata() TypeMetadata {
 	return md
 }
 
+// All resource Metadata (not lists) implement the ResourceMetadata interface.
+type ResourceMetadata interface {
+	GetObjectMetadata() ObjectMetadata
+}
+
 // ---- Metadata common to all resources ----
 type ObjectMetadata struct {
+}
+
+func (md ObjectMetadata) GetObjectMetadata() ObjectMetadata {
+	return md
 }
 
 // ---- Metadata common to all lists ----

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -126,8 +126,8 @@ func LoadClientConfig(f *string) (*api.ClientConfig, error) {
 type conversionHelper interface {
 	convertAPIToKVPair(unversioned.Resource) (*model.KVPair, error)
 	convertKVPairToAPI(*model.KVPair) (unversioned.Resource, error)
-	convertMetadataToKey(interface{}) (model.Key, error)
-	convertMetadataToListInterface(interface{}) (model.ListInterface, error)
+	convertMetadataToKey(unversioned.ResourceMetadata) (model.Key, error)
+	convertMetadataToListInterface(unversioned.ResourceMetadata) (model.ListInterface, error)
 }
 
 //TODO Plumb through revision data so that front end can do atomic operations.
@@ -171,7 +171,7 @@ func (c *Client) apply(apiObject unversioned.Resource, helper conversionHelper) 
 
 // Untyped get interface for deleting a single API object.  This is called from the typed
 // interface.
-func (c *Client) delete(metadata interface{}, helper conversionHelper) error {
+func (c *Client) delete(metadata unversioned.ResourceMetadata, helper conversionHelper) error {
 	if k, err := helper.convertMetadataToKey(metadata); err != nil {
 		return err
 	} else if err := c.backend.Delete(&model.KVPair{Key: k}); err != nil {
@@ -183,7 +183,7 @@ func (c *Client) delete(metadata interface{}, helper conversionHelper) error {
 
 // Untyped get interface for getting a single API object.  This is called from the typed
 // interface.  The result is
-func (c *Client) get(metadata interface{}, helper conversionHelper) (unversioned.Resource, error) {
+func (c *Client) get(metadata unversioned.ResourceMetadata, helper conversionHelper) (unversioned.Resource, error) {
 	if k, err := helper.convertMetadataToKey(metadata); err != nil {
 		return nil, err
 	} else if d, err := c.backend.Get(k); err != nil {
@@ -197,7 +197,7 @@ func (c *Client) get(metadata interface{}, helper conversionHelper) (unversioned
 
 // Untyped get interface for getting a list of API objects.  This is called from the typed
 // interface.  This updates the Items slice in the supplied List resource object.
-func (c *Client) list(metadata interface{}, helper conversionHelper, listp interface{}) error {
+func (c *Client) list(metadata unversioned.ResourceMetadata, helper conversionHelper, listp interface{}) error {
 	if l, err := helper.convertMetadataToListInterface(metadata); err != nil {
 		return err
 	} else if dos, err := c.backend.List(l); err != nil {

--- a/lib/client/hostendpoint.go
+++ b/lib/client/hostendpoint.go
@@ -99,7 +99,7 @@ func (h *hostEndpoints) List(metadata api.HostEndpointMetadata) (*api.HostEndpoi
 }
 
 // Convert a HostEndpointMetadata to a HostEndpointListInterface
-func (h *hostEndpoints) convertMetadataToListInterface(m interface{}) (model.ListInterface, error) {
+func (h *hostEndpoints) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	hm := m.(api.HostEndpointMetadata)
 	l := model.HostEndpointListOptions{
 		Hostname:   hm.Hostname,
@@ -109,7 +109,7 @@ func (h *hostEndpoints) convertMetadataToListInterface(m interface{}) (model.Lis
 }
 
 // Convert a HostEndpointMetadata to a HostEndpointKeyInterface
-func (h *hostEndpoints) convertMetadataToKey(m interface{}) (model.Key, error) {
+func (h *hostEndpoints) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	hm := m.(api.HostEndpointMetadata)
 	k := model.HostEndpointKey{
 		Hostname:   hm.Hostname,

--- a/lib/client/policy.go
+++ b/lib/client/policy.go
@@ -110,7 +110,7 @@ func (h *policies) List(metadata api.PolicyMetadata) (*api.PolicyList, error) {
 }
 
 // Convert a PolicyMetadata to a PolicyListInterface
-func (h *policies) convertMetadataToListInterface(m interface{}) (model.ListInterface, error) {
+func (h *policies) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	pm := m.(api.PolicyMetadata)
 	l := model.PolicyListOptions{
 		Name: pm.Name,
@@ -120,7 +120,7 @@ func (h *policies) convertMetadataToListInterface(m interface{}) (model.ListInte
 }
 
 // Convert a PolicyMetadata to a PolicyKeyInterface
-func (h *policies) convertMetadataToKey(m interface{}) (model.Key, error) {
+func (h *policies) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	pm := m.(api.PolicyMetadata)
 	k := model.PolicyKey{
 		Name: pm.Name,

--- a/lib/client/pool.go
+++ b/lib/client/pool.go
@@ -78,7 +78,7 @@ func (h *pools) List(metadata api.PoolMetadata) (*api.PoolList, error) {
 }
 
 // Convert a PoolMetadata to a PoolListInterface
-func (h *pools) convertMetadataToListInterface(m interface{}) (model.ListInterface, error) {
+func (h *pools) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	pm := m.(api.PoolMetadata)
 	l := model.PoolListOptions{
 		CIDR: pm.CIDR,
@@ -87,7 +87,7 @@ func (h *pools) convertMetadataToListInterface(m interface{}) (model.ListInterfa
 }
 
 // Convert a PoolMetadata to a PoolKeyInterface
-func (h *pools) convertMetadataToKey(m interface{}) (model.Key, error) {
+func (h *pools) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	pm := m.(api.PoolMetadata)
 	k := model.PoolKey{
 		CIDR: pm.CIDR,

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -78,7 +78,7 @@ func (h *profiles) List(metadata api.ProfileMetadata) (*api.ProfileList, error) 
 }
 
 // Convert a ProfileMetadata to a ProfileListInterface
-func (h *profiles) convertMetadataToListInterface(m interface{}) (model.ListInterface, error) {
+func (h *profiles) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	hm := m.(api.ProfileMetadata)
 	l := model.ProfileListOptions{
 		Name: hm.Name,
@@ -87,7 +87,7 @@ func (h *profiles) convertMetadataToListInterface(m interface{}) (model.ListInte
 }
 
 // Convert a ProfileMetadata to a ProfileKeyInterface
-func (h *profiles) convertMetadataToKey(m interface{}) (model.Key, error) {
+func (h *profiles) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	hm := m.(api.ProfileMetadata)
 	k := model.ProfileKey{
 		Name: hm.Name,

--- a/lib/client/tier.go
+++ b/lib/client/tier.go
@@ -78,7 +78,7 @@ func (h *tiers) List(metadata api.TierMetadata) (*api.TierList, error) {
 }
 
 // Convert a TierMetadata to a TierListInterface
-func (h *tiers) convertMetadataToListInterface(m interface{}) (model.ListInterface, error) {
+func (h *tiers) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	hm := m.(api.TierMetadata)
 	l := model.TierListOptions{
 		Name: hm.Name,
@@ -87,7 +87,7 @@ func (h *tiers) convertMetadataToListInterface(m interface{}) (model.ListInterfa
 }
 
 // Convert a TierMetadata to a TierKeyInterface
-func (h *tiers) convertMetadataToKey(m interface{}) (model.Key, error) {
+func (h *tiers) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	hm := m.(api.TierMetadata)
 	k := model.TierKey{
 		Name: hm.Name,

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -79,7 +79,7 @@ func (w *workloadEndpoints) List(metadata api.WorkloadEndpointMetadata) (*api.Wo
 }
 
 // Convert a WorkloadEndpointMetadata to a WorkloadEndpointListInterface
-func (w *workloadEndpoints) convertMetadataToListInterface(m interface{}) (model.ListInterface, error) {
+func (w *workloadEndpoints) convertMetadataToListInterface(m unversioned.ResourceMetadata) (model.ListInterface, error) {
 	hm := m.(api.WorkloadEndpointMetadata)
 	l := model.WorkloadEndpointListOptions{
 		Hostname:       hm.Hostname,
@@ -91,7 +91,7 @@ func (w *workloadEndpoints) convertMetadataToListInterface(m interface{}) (model
 }
 
 // Convert a WorkloadEndpointMetadata to a WorkloadEndpointKeyInterface
-func (w *workloadEndpoints) convertMetadataToKey(m interface{}) (model.Key, error) {
+func (w *workloadEndpoints) convertMetadataToKey(m unversioned.ResourceMetadata) (model.Key, error) {
 	hm := m.(api.WorkloadEndpointMetadata)
 	k := model.WorkloadEndpointKey{
 		Hostname:       hm.Hostname,


### PR DESCRIPTION
Add a ResourceMetadata interface and update internal interfaces to use ResourceMetadata instead of interface{}

Whilst ObjectMetadata doesn't yet contain any fields - it will do - namely revision information, and possibly other stuff in the future.   Adding the interface now allows the internal interfaces to look a little nicer.