### PR TITLE
Add ID to profile rules and ensure null is to written to tags and labels

### DIFF
--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -15,6 +15,7 @@
 package compat
 
 import (
+	"github.com/golang/glog"
 	"github.com/tigera/libcalico-go/lib/backend/api"
 	. "github.com/tigera/libcalico-go/lib/backend/model"
 )
@@ -126,6 +127,8 @@ func (c *ModelAdaptor) List(l ListInterface) ([]*KVPair, error) {
 }
 
 // Convert a Profile KVPair to separate KVPair types for Keys, Labels and Rules.
+// These separate KVPairs are used to write three separate objects that make up
+// a single profile.
 func toTagsLabelsRules(d *KVPair) (t, l, r *KVPair) {
 	p := d.Value.(Profile)
 	pk := d.Key.(ProfileKey)
@@ -142,6 +145,18 @@ func toTagsLabelsRules(d *KVPair) (t, l, r *KVPair) {
 	r = &KVPair{
 		Key:   ProfileRulesKey{pk},
 		Value: p.Rules,
+	}
+
+	// Fix up tags and labels so to be empty values rather than nil.  Felix does not
+	// expect a null value in the JSON, so we fix up to make Labels an empty map
+	// and tags an empty slice.
+	if p.Labels == nil {
+		glog.V(1).Info("Labels is nil - convert to empty map for backend")
+		l.Value = map[string]string{}
+	}
+	if p.Tags == nil {
+		glog.V(1).Info("Tags is nil - convert to empty map for backend")
+		t.Value = []string{}
 	}
 
 	return t, l, r

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -148,6 +148,7 @@ type Profile struct {
 }
 
 type ProfileRules struct {
+	ProfileID     string `json:"id,omitempty" validate:"omitempty"`
 	InboundRules  []Rule `json:"inbound_rules,omitempty" validate:"omitempty,dive"`
 	OutboundRules []Rule `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
 }

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -107,6 +107,7 @@ func (h *profiles) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 		Key: k,
 		Value: model.Profile{
 			Rules: model.ProfileRules{
+				ProfileID:     ap.Metadata.Name,
 				InboundRules:  rulesAPIToBackend(ap.Spec.IngressRules),
 				OutboundRules: rulesAPIToBackend(ap.Spec.EgressRules),
 			},

--- a/test/all.yaml
+++ b/test/all.yaml
@@ -62,9 +62,16 @@
       THING4: VALUE10/2-F
   spec:
     tags: [a, b, c, a1, update]
-    rules:
-      ingress:
-        - action: deny
-      egress:
-        - action: deny
+    ingress:
+      - action: deny
+    egress:
+      - action: deny
+- apiVersion: v1
+  kind: profile
+  metadata:
+    name: empty
+  spec:
+    ingress:
+      - action: deny
+ 
 


### PR DESCRIPTION
Add the profile ID to the profile rules object.  This is not part of the actual etcd felix spec, but is used by calioctl for some unknown reason.

Also, fix up processing to ensure null values are not written into empty profile tags or empty profile labels.