### PR TITLE
Don't omit empty endpoint data in backend

### DIFF
--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -144,8 +144,8 @@ type WorkloadEndpoint struct {
 	State      string            `json:"state"`
 	Name       string            `json:"name"`
 	Mac        net.MAC           `json:"mac"`
-	ProfileIDs []string          `json:"profile_ids,omitempty"`
-	IPv4Nets   []net.IPNet       `json:"ipv4_nets,omitempty"`
-	IPv6Nets   []net.IPNet       `json:"ipv6_nets,omitempty"`
-	Labels     map[string]string `json:"labels,omitempty"`
+	ProfileIDs []string          `json:"profile_ids"`
+	IPv4Nets   []net.IPNet       `json:"ipv4_nets"`
+	IPv6Nets   []net.IPNet       `json:"ipv6_nets"`
+	Labels     map[string]string `json:"labels"`
 }

--- a/lib/client/workloadendpoint.go
+++ b/lib/client/workloadendpoint.go
@@ -122,8 +122,8 @@ func (w *workloadEndpoints) convertAPIToKVPair(a unversioned.Resource) (*model.K
 		return nil, err
 	}
 
-	var ipv4Nets []net.IPNet
-	var ipv6Nets []net.IPNet
+	ipv4Nets := []net.IPNet{}
+	ipv6Nets := []net.IPNet{}
 	for _, n := range ah.Spec.IPNetworks {
 		if n.Version() == 4 {
 			ipv4Nets = append(ipv4Nets, n)


### PR DESCRIPTION
Python `calicoctl`, for one, seems to expect fields to be there even if empty.

e.g
```
core@k8s-master ~ $ calicoctl endpoint show
Traceback (most recent call last):
  File "<string>", line 145, in <module>
  File "calico_ctl/endpoint.py", line 145, in endpoint
  File "calico_ctl/endpoint.py", line 165, in endpoint_show
  File "site-packages/pycalico/datastore.py", line 128, in wrapped
  File "site-packages/pycalico/datastore.py", line 1184, in get_endpoints
  File "site-packages/pycalico/datastore_datatypes.py", line 292, in from_json
KeyError: 'ipv6_nets'
```