### PR TITLE
Remove profile ID from backend rules

### DIFF
--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -148,7 +148,6 @@ type Profile struct {
 }
 
 type ProfileRules struct {
-	ProfileID     string `json:"id,omitempty" validate:"omitempty"`
 	InboundRules  []Rule `json:"inbound_rules,omitempty" validate:"omitempty,dive"`
 	OutboundRules []Rule `json:"outbound_rules,omitempty" validate:"omitempty,dive"`
 }

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -107,7 +107,6 @@ func (h *profiles) convertAPIToKVPair(a unversioned.Resource) (*model.KVPair, er
 		Key: k,
 		Value: model.Profile{
 			Rules: model.ProfileRules{
-				ProfileID:     ap.Metadata.Name,
 				InboundRules:  rulesAPIToBackend(ap.Spec.IngressRules),
 				OutboundRules: rulesAPIToBackend(ap.Spec.EgressRules),
 			},


### PR DESCRIPTION
To be merged after calicoctl release that handles profiles without the id field in the backend,