### PR TITLE
Remove utils file and don't allow workload endpoints to be created

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -108,7 +108,7 @@ func (a apply) execute(client *client.Client, resource unversioned.Resource) (un
 	case api.Tier:
 		_, err = client.Tiers().Apply(&r)
 	case api.WorkloadEndpoint:
-		_, err = client.WorkloadEndpoints().Apply(&r)
+		err = fmt.Errorf("Workload endpoints cannot be managed directly")
 	default:
 		panic(fmt.Errorf("Unhandled resource type: %v", resource))
 	}

--- a/calicoctl/commands/client.go
+++ b/calicoctl/commands/client.go
@@ -15,19 +15,10 @@
 package commands
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"reflect"
-	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/calicoctl/resourcemgr"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/api/unversioned"
 	"github.com/tigera/libcalico-go/lib/client"
-	"github.com/tigera/libcalico-go/lib/net"
 )
 
 // Create a new CalicoClient using connection information in the specified

--- a/calicoctl/commands/client.go
+++ b/calicoctl/commands/client.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"github.com/tigera/libcalico-go/calicoctl/resourcemgr"
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+	"github.com/tigera/libcalico-go/lib/net"
+)
+
+// Create a new CalicoClient using connection information in the specified
+// filename (if it exists), dropping back to environment variables for any
+// parameter not loaded from file.
+func newClient(cf string) (*client.Client, error) {
+	if _, err := os.Stat(cf); err != nil {
+		glog.V(2).Infof("Config file cannot be read - reading config from environment")
+		cf = ""
+	}
+
+	cfg, err := client.LoadClientConfig(cf)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(2).Infof("Loaded client config: type=%v %#v", cfg.BackendType, cfg.BackendConfig)
+
+	c, err := client.New(*cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, err
+}

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -110,7 +110,7 @@ func (c create) execute(client *client.Client, resource unversioned.Resource) (u
 	case api.Tier:
 		_, err = client.Tiers().Create(&r)
 	case api.WorkloadEndpoint:
-		_, err = client.WorkloadEndpoints().Create(&r)
+		err = fmt.Errorf("Workload endpoints cannot be managed directly")
 	default:
 		panic(fmt.Errorf("Unhandled resource type: %v", resource))
 	}

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -118,7 +118,7 @@ func (d delete) execute(client *client.Client, resource unversioned.Resource) (u
 	case api.Tier:
 		err = client.Tiers().Delete(r.Metadata)
 	case api.WorkloadEndpoint:
-		err = client.WorkloadEndpoints().Delete(r.Metadata)
+		err = fmt.Errorf("Workload endpoints cannot be managed directly")
 	default:
 		panic(fmt.Errorf("Unhandled resource type: %v", resource))
 	}

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -110,7 +110,7 @@ func (c replace) execute(client *client.Client, resource unversioned.Resource) (
 	case api.Tier:
 		_, err = client.Tiers().Update(&r)
 	case api.WorkloadEndpoint:
-		_, err = client.WorkloadEndpoints().Update(&r)
+		err = fmt.Errorf("Workload endpoints cannot be managed directly")
 	default:
 		panic(fmt.Errorf("Unhandled resource type: %v", resource))
 	}

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 
@@ -159,7 +158,7 @@ type commandResults struct {
 	resources []unversioned.Resource
 }
 
-// Common function for configuration commands apply, create, replace and delete.  All
+// Common function for configuration commands apply, create, replace, get and delete.  All
 // these commands:
 // 	-  Load resources from file (or if not specified determine the resource from
 // 	   the command line options).
@@ -181,7 +180,11 @@ func executeConfigCommand(args map[string]interface{}, cmd commandInterface) com
 
 		resources = convertToSliceOfResources(r)
 	} else if r, err := getResourceFromArguments(args); err != nil {
-		return commandResults{err: err, fileInvalid: true}
+		// Filename is not specific so extract the resource from the arguments.  This
+		// is only useful for delete and get functions - but we don't need to check that
+		// here since the command syntax requires a filename for the other resource
+		// management commands.
+		return commandResults{err: err}
 	} else {
 		// We extracted a single resource type with identifiers from the CLI, convert to
 		// a list for simpler handling.

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -30,29 +30,6 @@ import (
 	"github.com/tigera/libcalico-go/lib/net"
 )
 
-// Create a new CalicoClient using connection information in the specified
-// filename (if it exists), dropping back to environment variables for any
-// parameter not loaded from file.
-func newClient(cf string) (*client.Client, error) {
-	if _, err := os.Stat(cf); err != nil {
-		glog.V(2).Infof("Config file cannot be read - reading config from environment")
-		cf = ""
-	}
-
-	cfg, err := client.LoadClientConfig(cf)
-	if err != nil {
-		return nil, err
-	}
-	glog.V(2).Infof("Loaded client config: type=%v %#v", cfg.BackendType, cfg.BackendConfig)
-
-	c, err := client.New(*cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return c, err
-}
-
 // Convert loaded resources to a slice of resources for easier processing.
 // The loaded resources may be a slice containing resources and resource lists, or
 // may be a single resource or a single resource list.  This function handles the
@@ -182,7 +159,7 @@ type commandResults struct {
 	resources []unversioned.Resource
 }
 
-// Common function for configuration commands create, replace and delete.  All
+// Common function for configuration commands apply, create, replace and delete.  All
 // these commands:
 // 	-  Load resources from file (or if not specified determine the resource from
 // 	   the command line options).


### PR DESCRIPTION
Split the utils file into:
-  client.go   [handles creating a new client]
-  resources.go  [handles generic resource command processing]

A few additional code comments.

Don't allow workload endpoints to be created.  They can be viewed though using get.