### PR TITLE
Build out calicoctl get command to display PS style table outputs (and group resource specific processing)

### DIFF
--- a/calicoctl/calicoctl.go
+++ b/calicoctl/calicoctl.go
@@ -70,6 +70,7 @@ See 'calicoctl <command> --help' to read about a specific subcommand.`
 	}
 
 	if err != nil {
+		fmt.Printf("Error executing command: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -19,9 +19,6 @@ import (
 
 	"github.com/docopt/docopt-go"
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/api/unversioned"
-	"github.com/tigera/libcalico-go/lib/client"
 )
 
 func Apply(args []string) error {
@@ -51,8 +48,7 @@ Options:
 		return nil
 	}
 
-	cmd := apply{}
-	results := executeConfigCommand(parsedArgs, cmd)
+	results := executeConfigCommand(parsedArgs, actionApply)
 	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
@@ -86,34 +82,4 @@ Options:
 	}
 
 	return results.err
-}
-
-// commandInterface for create command.
-// Maps the generic resource types to the typed client interface.
-type apply struct {
-	skipIfExists bool
-}
-
-func (a apply) execute(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
-	var err error
-	switch r := resource.(type) {
-	case api.HostEndpoint:
-		_, err = client.HostEndpoints().Apply(&r)
-	case api.Policy:
-		_, err = client.Policies().Apply(&r)
-	case api.Pool:
-		_, err = client.Pools().Apply(&r)
-	case api.Profile:
-		_, err = client.Profiles().Apply(&r)
-	case api.Tier:
-		_, err = client.Tiers().Apply(&r)
-	case api.WorkloadEndpoint:
-		err = fmt.Errorf("Workload endpoints cannot be managed directly")
-	case api.BGPPeer:
-		_, err = client.BGPPeers().Apply(&r)
-	default:
-		panic(fmt.Errorf("Unhandled resource type: %v", resource))
-	}
-
-	return resource, err
 }

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -19,10 +19,6 @@ import (
 
 	"github.com/docopt/docopt-go"
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/api/unversioned"
-	"github.com/tigera/libcalico-go/lib/client"
-	"github.com/tigera/libcalico-go/lib/errors"
 )
 
 func Create(args []string) error {
@@ -53,8 +49,7 @@ Options:
 		return nil
 	}
 
-	cmd := create{skipIfExists: parsedArgs["--skip-exists"].(bool)}
-	results := executeConfigCommand(parsedArgs, cmd)
+	results := executeConfigCommand(parsedArgs, actionCreate)
 	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
@@ -88,45 +83,4 @@ Options:
 	}
 
 	return results.err
-}
-
-// commandInterface for create command.
-// Maps the generic resource types to the typed client interface.
-type create struct {
-	skipIfExists bool
-}
-
-func (c create) execute(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
-	var err error
-	switch r := resource.(type) {
-	case api.HostEndpoint:
-		_, err = client.HostEndpoints().Create(&r)
-	case api.Policy:
-		_, err = client.Policies().Create(&r)
-	case api.Pool:
-		_, err = client.Pools().Create(&r)
-	case api.Profile:
-		_, err = client.Profiles().Create(&r)
-	case api.Tier:
-		_, err = client.Tiers().Create(&r)
-	case api.WorkloadEndpoint:
-		err = fmt.Errorf("Workload endpoints cannot be managed directly")
-	case api.BGPPeer:
-		_, err = client.BGPPeers().Create(&r)
-	default:
-		panic(fmt.Errorf("Unhandled resource type: %v", resource))
-	}
-
-	if err == nil {
-		return resource, nil
-	}
-
-	// Handle resource does not exist errors explicitly.
-	switch err.(type) {
-	case errors.ErrorResourceAlreadyExists:
-		if c.skipIfExists {
-			return resource, nil
-		}
-	}
-	return nil, err
 }

--- a/calicoctl/commands/delete.go
+++ b/calicoctl/commands/delete.go
@@ -20,10 +20,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/api/unversioned"
-	"github.com/tigera/libcalico-go/lib/client"
-	"github.com/tigera/libcalico-go/lib/errors"
 )
 
 func Delete(args []string) error {
@@ -66,8 +62,7 @@ Options:
 		return nil
 	}
 
-	cmd := delete{skipIfNotExists: parsedArgs["--skip-not-exists"].(bool)}
-	results := executeConfigCommand(parsedArgs, cmd)
+	results := executeConfigCommand(parsedArgs, actionDelete)
 	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
@@ -101,45 +96,4 @@ Options:
 	}
 
 	return results.err
-}
-
-// commandInterface for delete command.
-// Maps the generic resource types to the typed client interface.
-type delete struct {
-	skipIfNotExists bool
-}
-
-func (d delete) execute(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
-	var err error
-	switch r := resource.(type) {
-	case api.HostEndpoint:
-		err = client.HostEndpoints().Delete(r.Metadata)
-	case api.Policy:
-		err = client.Policies().Delete(r.Metadata)
-	case api.Pool:
-		err = client.Pools().Delete(r.Metadata)
-	case api.Profile:
-		err = client.Profiles().Delete(r.Metadata)
-	case api.Tier:
-		err = client.Tiers().Delete(r.Metadata)
-	case api.WorkloadEndpoint:
-		err = fmt.Errorf("Workload endpoints cannot be managed directly")
-	case api.BGPPeer:
-		err = client.BGPPeers().Delete(r.Metadata)
-	default:
-		panic(fmt.Errorf("Unhandled resource type: %v", resource))
-	}
-
-	if err == nil {
-		return resource, nil
-	}
-
-	// Handle resource does not exist errors explicitly.
-	switch err.(type) {
-	case errors.ErrorResourceDoesNotExist:
-		if d.skipIfNotExists {
-			return resource, nil
-		}
-	}
-	return nil, err
 }

--- a/calicoctl/commands/get.go
+++ b/calicoctl/commands/get.go
@@ -16,23 +16,18 @@ package commands
 
 import (
 	"github.com/docopt/docopt-go"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/client"
 
 	"fmt"
+	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/api/unversioned"
 )
 
 func Get(args []string) error {
 	doc := EtcdIntro + `Display one or many resources identified by file, stdin or resource type and name.
 
-Possible resource types include: policy
-
-By specifying the output as 'template' and providing a Go template as the value
-of the --template flag, you can filter the attributes of the fetched resource(s).
+By specifying the output as 'go-template' and providing a Go template as the value
+of the --go-template flag, you can filter the attributes of the fetched resource(s).
 
 Usage:
   calicoctl get ([--tier=<TIER>] [--hostname=<HOSTNAME>] [--scope=<SCOPE>] (<KIND> [<NAME>]) |
@@ -49,7 +44,8 @@ Examples:
 
 Options:
   -f --filename=<FILENAME>     Filename to use to get the resource.  If set to "-" loads from stdin.
-  -o --output=<OUTPUT FORMAT>  Output format.  One of: yaml, json.  [Default: yaml]
+  -o --output=<OUTPUT FORMAT>  Output format.  One of: ps, wide, custom-columns=..., yaml, json,
+                               go-template=..., go-template-file=...   [Default: ps]
   -t --tier=<TIER>             The policy tier.
   -n --hostname=<HOSTNAME>     The hostname.
   -c --config=<CONFIG>         Filename containing connection configuration in YAML or JSON format.
@@ -66,8 +62,54 @@ Options:
 		return nil
 	}
 
-	cmd := get{}
-	results := executeConfigCommand(parsedArgs, cmd)
+	var rp resourcePrinter
+	output := parsedArgs["--output"].(string)
+	switch output {
+	case "yaml":
+		rp = resourcePrinterYAML{}
+	case "json":
+		rp = resourcePrinterJSON{}
+	case "ps":
+		rp = resourcePrinterTable{wide: false}
+	case "wide":
+		rp = resourcePrinterTable{wide: true}
+	default:
+		// Output format may be a key=value pair, so split on "=" to find out.  Pull
+		// out the key and value, and split the value by "," as some options allow
+		// a multiple-valued value.
+		outputParms := strings.SplitN(output, "=", 2)
+		outputKey := outputParms[0]
+		outputValue := ""
+		outputValues := []string{}
+		if len(outputParms) == 2 {
+			outputValue = outputParms[1]
+			outputValues = strings.Split(outputValue, ",")
+		}
+
+		switch outputKey {
+		case "go-template":
+			if outputValue == "" {
+				return fmt.Errorf("need to specify a template")
+			}
+			rp = resourcePrinterTemplate{template: outputValue}
+		case "go-template-file":
+			if outputValue == "" {
+				return fmt.Errorf("need to specify a template file")
+			}
+			rp = resourcePrinterTemplateFile{templateFile: outputValue}
+		case "custom-columns":
+			if outputValue == "" {
+				return fmt.Errorf("need to specify at least one column")
+			}
+			rp = resourcePrinterTable{headings: outputValues}
+		}
+	}
+
+	if rp == nil {
+		return fmt.Errorf("unrecognized output format '%s'", output)
+	}
+
+	results := executeConfigCommand(parsedArgs, actionList)
 	glog.V(2).Infof("results: %+v", results)
 
 	if results.err != nil {
@@ -75,44 +117,5 @@ Options:
 		return err
 	}
 
-	// TODO Handle better - results should be groups as per input file
-	// For simplicity convert the returned list of resources to expand any lists
-	resources := convertToSliceOfResources(results.resources)
-
-	if output, err := yaml.Marshal(resources); err != nil {
-		fmt.Printf("Error outputing data: %v", err)
-	} else {
-		fmt.Printf("%s", string(output))
-	}
-
-	return nil
-}
-
-// commandInterface for replace command.
-// Maps the generic resource types to the typed client interface.
-type get struct {
-}
-
-func (g get) execute(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
-	var err error
-	switch r := resource.(type) {
-	case api.HostEndpoint:
-		resource, err = client.HostEndpoints().List(r.Metadata)
-	case api.Policy:
-		resource, err = client.Policies().List(r.Metadata)
-	case api.Pool:
-		resource, err = client.Pools().List(r.Metadata)
-	case api.Profile:
-		resource, err = client.Profiles().List(r.Metadata)
-	case api.Tier:
-		resource, err = client.Tiers().List(r.Metadata)
-	case api.WorkloadEndpoint:
-		resource, err = client.WorkloadEndpoints().List(r.Metadata)
-	case api.BGPPeer:
-		resource, err = client.BGPPeers().List(r.Metadata)
-	default:
-		panic(fmt.Errorf("Unhandled resource type: %v", resource))
-	}
-
-	return resource, err
+	return rp.print(results.resources)
 }

--- a/calicoctl/commands/printer.go
+++ b/calicoctl/commands/printer.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+
+	"bytes"
+	"encoding/json"
+	"os"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"github.com/tigera/libcalico-go/calicoctl/resourcemgr"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+)
+
+type resourcePrinter interface {
+	print(resources []unversioned.Resource) error
+}
+
+// resourcePrinterJSON implements the resourcePrinter interface and is used to display
+// a slice of resources in JSON format.
+type resourcePrinterJSON struct{}
+
+func (r resourcePrinterJSON) print(resources []unversioned.Resource) error {
+	// The supplied slice of resources may contain actual resource types as well as
+	// resource lists (which themselves contain a slice of actual resources).
+	// For simplicity, expand any resource lists so that we have a flat slice of
+	// real resources.
+	resources = convertToSliceOfResources(resources)
+	if output, err := json.MarshalIndent(resources, "", "  "); err != nil {
+		return err
+	} else {
+		fmt.Printf("%s\n", string(output))
+	}
+	return nil
+}
+
+// resourcePrinterYAML implements the resourcePrinter interface and is used to display
+// a slice of resources in YAML format.
+type resourcePrinterYAML struct{}
+
+func (r resourcePrinterYAML) print(resources []unversioned.Resource) error {
+	// The supplied slice of resources may contain actual resource types as well as
+	// resource lists (which themselves contain a slice of actual resources).
+	// For simplicity, expand any resource lists so that we have a flat slice of
+	// real resources.
+	resources = convertToSliceOfResources(resources)
+	if output, err := yaml.Marshal(resources); err != nil {
+		return err
+	} else {
+		fmt.Printf("%s", string(output))
+	}
+	return nil
+}
+
+// resourcePrinterTable implements the resourcePrinter interface and is used to display
+// a slice of resources in ps table format.
+type resourcePrinterTable struct {
+	// The headings to display in the table.  If this is nil, the default headings for the
+	// resource are used instead (in which case the `wide` boolean below is used to specify
+	// whether wide or narrow format is required.
+	headings []string
+
+	// Wide format.  When headings have not been explicitly specified, this is used to
+	// determine whether to the resource-specific default wide or narrow headings.
+	wide bool
+}
+
+func (r resourcePrinterTable) print(resources []unversioned.Resource) error {
+	glog.V(2).Infof("Output in table format (wide=%v)", r.wide)
+	for _, resource := range resources {
+		// Get the resource manager for the resource type.
+		rm := resourcemgr.GetResourceManager(resource)
+
+		// If no headings have been specified then we must be using the default
+		// headings for that resource type.
+		headings := r.headings
+		if r.headings == nil {
+			headings = rm.GetTableDefaultHeadings(r.wide)
+		}
+
+		// Look up the template string for the specific resource type.
+		tpls, err := rm.GetTableTemplate(headings)
+		if err != nil {
+			return err
+		}
+
+		// Convert the template string into a template - we need to include the join
+		// function.
+		fns := template.FuncMap{
+			"join": join,
+		}
+		tmpl, err := template.New("get").Funcs(fns).Parse(tpls)
+		if err != nil {
+			panic(err)
+		}
+
+		// Use a tabwriter to write out the teplate - this provides better formatting.
+		writer := tabwriter.NewWriter(os.Stdout, 5, 1, 3, ' ', 0)
+		err = tmpl.Execute(writer, resource)
+		if err != nil {
+			panic(err)
+		}
+		writer.Flush()
+
+		// Templates for ps format are internally defined and therefore we should not
+		// hit errors writing the table formats.
+		if err != nil {
+			panic(err)
+		}
+
+		// Leave a gap after each table.
+		fmt.Printf("\n")
+	}
+	return nil
+}
+
+// resourcePrinterTemplateFile implements the resourcePrinter interface and is used to display
+// a slice of resources using a user-defined go-lang template specified in a file.
+type resourcePrinterTemplateFile struct {
+	templateFile string
+}
+
+func (r resourcePrinterTemplateFile) print(resources []unversioned.Resource) error {
+	template, err := ioutil.ReadFile(r.templateFile)
+	if err != nil {
+		return err
+	}
+	rp := resourcePrinterTemplate{template: string(template)}
+	return rp.print(resources)
+}
+
+// resourcePrinterTemplate implements the resourcePrinter interface and is used to display
+// a slice of resources using a user-defined go-lang template string.
+type resourcePrinterTemplate struct {
+	template string
+}
+
+func (r resourcePrinterTemplate) print(resources []unversioned.Resource) error {
+	// We include a join function in the template as it's useful for multi
+	// value columns.
+	fns := template.FuncMap{
+		"join": join,
+	}
+	tmpl, err := template.New("get").Funcs(fns).Parse(r.template)
+	if err != nil {
+		return err
+	}
+
+	err = tmpl.Execute(os.Stdout, resources)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// join is similar to strings.Join() but takes an arbitrary slice of interfaces and converts
+// each to its string represenation and joins them together with the provided separator
+// string.
+func join(items interface{}, separator string) string {
+	// If this is a slice of strings - just use the strings.Join function.
+	switch s := items.(type) {
+	case []string:
+		return strings.Join(s, separator)
+	}
+
+	// Otherwise, provided this is a slice, just convert each item to a string and
+	// join together.
+	switch reflect.TypeOf(items).Kind() {
+	case reflect.Slice:
+		slice := reflect.ValueOf(items)
+		buf := new(bytes.Buffer)
+		for i := 0; i < slice.Len(); i++ {
+			if i > 0 {
+				buf.WriteString(separator)
+			}
+			fmt.Fprint(buf, slice.Index(i).Interface())
+		}
+		return buf.String()
+	}
+
+	// The supplied items is not a slice - so just convert to a string.
+	return fmt.Sprint(items)
+}

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -20,9 +20,6 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/api"
-	"github.com/tigera/libcalico-go/lib/api/unversioned"
-	"github.com/tigera/libcalico-go/lib/client"
 )
 
 func Replace(args []string) error {
@@ -54,8 +51,7 @@ Options:
 		return nil
 	}
 
-	cmd := replace{}
-	results := executeConfigCommand(parsedArgs, cmd)
+	results := executeConfigCommand(parsedArgs, actionUpdate)
 	glog.V(2).Infof("results: %+v", results)
 
 	if results.fileInvalid {
@@ -89,33 +85,4 @@ Options:
 	}
 
 	return results.err
-}
-
-// commandInterface for replace command.
-// Maps the generic resource types to the typed client interface.
-type replace struct {
-}
-
-func (c replace) execute(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
-	var err error
-	switch r := resource.(type) {
-	case api.HostEndpoint:
-		_, err = client.HostEndpoints().Update(&r)
-	case api.Policy:
-		_, err = client.Policies().Update(&r)
-	case api.Pool:
-		_, err = client.Pools().Update(&r)
-	case api.Profile:
-		_, err = client.Profiles().Update(&r)
-	case api.Tier:
-		_, err = client.Tiers().Update(&r)
-	case api.WorkloadEndpoint:
-		err = fmt.Errorf("Workload endpoints cannot be managed directly")
-	case api.BGPPeer:
-		_, err = client.BGPPeers().Update(&r)
-	default:
-		panic(fmt.Errorf("Unhandled resource type: %v", resource))
-	}
-
-	return resource, err
 }

--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -26,8 +26,19 @@ import (
 	"github.com/tigera/libcalico-go/lib/api"
 	"github.com/tigera/libcalico-go/lib/api/unversioned"
 	"github.com/tigera/libcalico-go/lib/client"
+	calicoErrors "github.com/tigera/libcalico-go/lib/errors"
 	"github.com/tigera/libcalico-go/lib/net"
 	"github.com/tigera/libcalico-go/lib/scope"
+)
+
+type action int
+
+const (
+	actionApply action = iota
+	actionCreate
+	actionUpdate
+	actionDelete
+	actionList
 )
 
 // Convert loaded resources to a slice of resources for easier processing.
@@ -79,19 +90,13 @@ func convertToSliceOfResources(loaded interface{}) []unversioned.Resource {
 	return r
 }
 
-// Return a resource instance from the command line arguments.
+// getResourceFromArguments returns a resource instance from the command line arguments.
 func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource, error) {
 	kind := args["<KIND>"].(string)
-	stringOrBlank := func(argName string) string {
-		if args[argName] != nil {
-			return args[argName].(string)
-		}
-		return ""
-	}
-	name := stringOrBlank("<NAME>")
-	tier := stringOrBlank("--tier")
-	hostname := stringOrBlank("--hostname")
-	resScope := stringOrBlank("--scope")
+	name := argStringOrBlank(args, "<NAME>")
+	tier := argStringOrBlank(args, "--tier")
+	hostname := argStringOrBlank(args, "--hostname")
+	resScope := argStringOrBlank(args, "--scope")
 	switch strings.ToLower(kind) {
 	case "hostendpoints":
 		fallthrough
@@ -159,12 +164,7 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 	}
 }
 
-// Interface to execute a command for a specific resource type.
-type commandInterface interface {
-	execute(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error)
-}
-
-// Results from executing a CLI command
+// commandResults contains the results from executing a CLI command
 type commandResults struct {
 	// Whether the input file was invalid.
 	fileInvalid bool
@@ -187,13 +187,15 @@ type commandResults struct {
 	resources []unversioned.Resource
 }
 
-// Common function for configuration commands apply, create, replace, get and delete.  All
-// these commands:
+// executeConfigCommand is main function called by all of the resource management commands
+// in calicoctl (apply, create, replace, get and delete).  This provides common function
+// for all these commands:
 // 	-  Load resources from file (or if not specified determine the resource from
 // 	   the command line options).
 // 	-  Convert the loaded resources into a list of resources (easier to handle)
-// 	-  Process each resource individually, collate results and exit on the first error.
-func executeConfigCommand(args map[string]interface{}, cmd commandInterface) commandResults {
+// 	-  Process each resource individually, fanning out to the appropriate methods on
+//	   the client interface, collate results and exit on the first error.
+func executeConfigCommand(args map[string]interface{}, action action) commandResults {
 	var r interface{}
 	var err error
 	var resources []unversioned.Resource
@@ -258,7 +260,7 @@ func executeConfigCommand(args map[string]interface{}, cmd commandInterface) com
 	// Now execute the command on each resource in order, exiting as soon as we hit an
 	// error.
 	for _, r := range resources {
-		r, err = cmd.execute(client, r)
+		r, err = executeResourceAction(args, client, r, action)
 		if err != nil {
 			results.err = err
 			break
@@ -268,4 +270,60 @@ func executeConfigCommand(args map[string]interface{}, cmd commandInterface) com
 	}
 
 	return results
+}
+
+// argStringOrBlank returns the requested argument as a string, or as a blank
+// string if the argument is not present.
+func argStringOrBlank(args map[string]interface{}, argName string) string {
+	if args[argName] != nil {
+		return args[argName].(string)
+	}
+	return ""
+}
+
+// argBoolOrFalse returns the requested argument as a boolean, or as false
+// if the argument is not present.
+func argBoolOrFalse(args map[string]interface{}, argName string) bool {
+	if args[argName] != nil {
+		return args[argName].(bool)
+	}
+	return false
+}
+
+// execureResourceAction fans out the specific resource action to the appropriate method
+// on the ResourceManager for the specific resource.
+func executeResourceAction(args map[string]interface{}, client *client.Client, resource unversioned.Resource, action action) (unversioned.Resource, error) {
+	rm := resourcemgr.GetResourceManager(resource)
+	var err error
+	var resourceOut unversioned.Resource
+
+	switch action {
+	case actionApply:
+		resourceOut, err = rm.Apply(client, resource)
+	case actionCreate:
+		resourceOut, err = rm.Create(client, resource)
+	case actionUpdate:
+		resourceOut, err = rm.Update(client, resource)
+	case actionDelete:
+		resourceOut, err = rm.Delete(client, resource)
+	case actionList:
+		resourceOut, err = rm.List(client, resource)
+	}
+
+	// Skip over some errors depending on command line options.
+	if err != nil {
+		skip := false
+		switch err.(type) {
+		case calicoErrors.ErrorResourceAlreadyExists:
+			skip = argBoolOrFalse(args, "--skip-exists")
+		case calicoErrors.ErrorResourceDoesNotExist:
+			skip = argBoolOrFalse(args, "--skip-not-exists")
+		}
+		if skip {
+			resourceOut = resource
+			err = nil
+		}
+	}
+
+	return resourceOut, err
 }

--- a/calicoctl/resourcemgr/bgppeer.go
+++ b/calicoctl/resourcemgr/bgppeer.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewBGPPeer(),
+		api.NewBGPPeerList(),
+		[]string{"SCOPE", "PEERIP", "HOSTNAME"},
+		[]string{"SCOPE", "PEERIP", "HOSTNAME", "ASN"},
+		map[string]string{
+			"SCOPE":    "{{.Metadata.Scope}}",
+			"PEERIP":   "{{.Metadata.PeerIP}}",
+			"HOSTNAME": "{{.Metadata.Hostname}}",
+			"ASN":      "{{.Spec.ASNumber}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.BGPPeer)
+			return client.BGPPeers().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.BGPPeer)
+			return client.BGPPeers().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.BGPPeer)
+			return client.BGPPeers().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.BGPPeer)
+			return nil, client.BGPPeers().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.BGPPeer)
+			return client.BGPPeers().List(r.Metadata)
+		},
+	)
+}

--- a/calicoctl/resourcemgr/doc.go
+++ b/calicoctl/resourcemgr/doc.go
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 /*
-Package resourcemgr implements generic resource handling methods.  This provides
-a mechanism for creating specific resources from a JSON or YAML input.
+Package resourcemgr implements generic resource handling methods.  This includes:
+	- a mechanism for creating specific resources from a JSON or YAML input.
+	- an untyped resource management interface for each resource type
+	- table template data for each resource type
 */
 package resourcemgr

--- a/calicoctl/resourcemgr/hostendpoint.go
+++ b/calicoctl/resourcemgr/hostendpoint.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewHostEndpoint(),
+		api.NewHostEndpointList(),
+		[]string{"HOSTNAME", "NAME"},
+		[]string{"HOSTNAME", "NAME", "INTERFACE", "IPS", "PROFILES"},
+		map[string]string{
+			"HOSTNAME":  "{{.Metadata.Hostname}}",
+			"NAME":      "{{.Metadata.Name}}",
+			"INTERFACE": "{{.Spec.InterfaceName}}",
+			"IPS":       "{{join .Spec.ExpectedIPs \",\"}}",
+			"PROFILES":  "{{join .Spec.Profiles \",\"}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.HostEndpoint)
+			return client.HostEndpoints().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.HostEndpoint)
+			return client.HostEndpoints().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.HostEndpoint)
+			return client.HostEndpoints().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.HostEndpoint)
+			return nil, client.HostEndpoints().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.HostEndpoint)
+			return client.HostEndpoints().Get(r.Metadata)
+		},
+	)
+}

--- a/calicoctl/resourcemgr/policy.go
+++ b/calicoctl/resourcemgr/policy.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewPolicy(),
+		api.NewPolicyList(),
+		[]string{"NAME", "TIER"},
+		[]string{"NAME", "TIER", "ORDER", "SELECTOR"},
+		map[string]string{
+			"NAME":     "{{.Metadata.Name}}",
+			"TIER":     "{{.Metadata.Tier}}",
+			"ORDER":    "{{.Spec.Order}}",
+			"SELECTOR": "{{.Spec.Selector}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Policy)
+			return client.Policies().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Policy)
+			return client.Policies().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Policy)
+			return client.Policies().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Policy)
+			return nil, client.Policies().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Policy)
+			return client.Policies().List(r.Metadata)
+		},
+	)
+}

--- a/calicoctl/resourcemgr/pool.go
+++ b/calicoctl/resourcemgr/pool.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewPool(),
+		api.NewPoolList(),
+		[]string{"CIDR"},
+		[]string{"CIDR", "NAT", "IPIP"},
+		map[string]string{
+			"CIDR": "{{.Metadata.CIDR}}",
+			"NAT":  "{{.Spec.NATOutgoing}}",
+			"IPIP": "{{if .Spec.IPIP}}{{.Spec.IPIP.Enabled}}{{else}}false{{end}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Pool)
+			return client.Pools().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Pool)
+			return client.Pools().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Pool)
+			return client.Pools().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Pool)
+			return nil, client.Pools().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Pool)
+			return client.Pools().List(r.Metadata)
+		},
+	)
+}

--- a/calicoctl/resourcemgr/profile.go
+++ b/calicoctl/resourcemgr/profile.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewProfile(),
+		api.NewProfileList(),
+		[]string{"NAME"},
+		[]string{"NAME", "TAGS"},
+		map[string]string{
+			"NAME": "{{.Metadata.Name}}",
+			"TAGS": "{{join .Spec.Tags \",\"}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Profile)
+			return client.Profiles().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Profile)
+			return client.Profiles().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Profile)
+			return client.Profiles().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Profile)
+			return nil, client.Profiles().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Profile)
+			return client.Profiles().List(r.Metadata)
+		},
+	)
+}

--- a/calicoctl/resourcemgr/resourcemgr.go
+++ b/calicoctl/resourcemgr/resourcemgr.go
@@ -19,63 +19,100 @@ import (
 
 	"fmt"
 	"reflect"
+	"strings"
 
 	"io/ioutil"
 	"os"
 
-	"github.com/tigera/libcalico-go/lib/api"
 	"github.com/tigera/libcalico-go/lib/api/unversioned"
+
+	"bytes"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
+	"github.com/tigera/libcalico-go/lib/client"
 	"github.com/tigera/libcalico-go/lib/validator"
 )
+
+// The ResourceManager interface provides useful function for each resource type.  This includes:
+//	-  Commands to assist with generation of table output format of resources
+//	-  Commands to manage resource instances through an un-typed interface.
+type ResourceManager interface {
+	GetTableDefaultHeadings(wide bool) []string
+	GetTableTemplate(columns []string) (string, error)
+	Apply(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error)
+	Create(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error)
+	Update(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error)
+	Delete(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error)
+	List(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error)
+}
+
+type ResourceActionCommand func(*client.Client, unversioned.Resource) (unversioned.Resource, error)
 
 // ResourceHelper encapsulates details about a specific version of a specific resource:
 //
 // 	-  The type of resource (Kind and Version).  This includes the list types (even
 //	   though they are not strictly resources themselves).
 // 	-  The concrete resource struct for this version
+//	-  Template strings used to format output for each resource type.
+//	-  Functions to handle resource management actions (apply, create, update, delete, list).
+//         These functions are an untyped interface (generic Resource interfaces) that map through
+//         to the Calicc clients typed interface.
 type resourceHelper struct {
-	typeMetadata unversioned.TypeMetadata
-	resourceType reflect.Type
+	typeMetadata      unversioned.TypeMetadata
+	resourceType      reflect.Type
+	tableHeadings     []string
+	tableHeadingsWide []string
+	headingsMap       map[string]string
+	isList            bool
+	apply             ResourceActionCommand
+	create            ResourceActionCommand
+	update            ResourceActionCommand
+	delete            ResourceActionCommand
+	list              ResourceActionCommand
 }
 
 func (r resourceHelper) String() string {
-	return fmt.Sprintf("Resource %s, version %s", r.typeMetadata.Kind, r.typeMetadata.APIVersion)
+	return fmt.Sprintf("Resource(%s %s)", r.typeMetadata.Kind, r.typeMetadata.APIVersion)
 }
 
 // Store a resourceHelper for each resource unversioned.TypeMetadata.
 var helpers map[unversioned.TypeMetadata]resourceHelper
 
-// Register all of the available resource types, this includes resource lists as well.
-func init() {
-	helpers = make(map[unversioned.TypeMetadata]resourceHelper)
+func registerResource(res unversioned.Resource, resList unversioned.Resource,
+	tableHeadings []string, tableHeadingsWide []string, headingsMap map[string]string,
+	apply, create, update, delete, list ResourceActionCommand) {
 
-	registerHelper := func(t unversioned.Resource) {
-		tmd := t.GetTypeMetadata()
-		rh := resourceHelper{
-			tmd,
-			reflect.ValueOf(t).Elem().Type(),
-		}
-		helpers[tmd] = rh
+	if helpers == nil {
+		helpers = make(map[unversioned.TypeMetadata]resourceHelper)
 	}
 
-	// Register all API resources supported by the generic resource interface.
-	registerHelper(api.NewTier())
-	registerHelper(api.NewTierList())
-	registerHelper(api.NewPolicy())
-	registerHelper(api.NewPolicyList())
-	registerHelper(api.NewPool())
-	registerHelper(api.NewPoolList())
-	registerHelper(api.NewProfile())
-	registerHelper(api.NewProfileList())
-	registerHelper(api.NewHostEndpoint())
-	registerHelper(api.NewHostEndpointList())
-	registerHelper(api.NewWorkloadEndpoint())
-	registerHelper(api.NewWorkloadEndpointList())
-	registerHelper(api.NewBGPPeer())
-	registerHelper(api.NewBGPPeerList())
+	tmd := res.GetTypeMetadata()
+	rh := resourceHelper{
+		typeMetadata:      tmd,
+		resourceType:      reflect.ValueOf(res).Elem().Type(),
+		tableHeadings:     tableHeadings,
+		tableHeadingsWide: tableHeadingsWide,
+		headingsMap:       headingsMap,
+		isList:            false,
+		apply:             apply,
+		create:            create,
+		update:            update,
+		delete:            delete,
+		list:              list,
+	}
+	helpers[tmd] = rh
+
+	tmd = resList.GetTypeMetadata()
+	rh = resourceHelper{
+		typeMetadata:      tmd,
+		resourceType:      reflect.ValueOf(resList).Elem().Type(),
+		tableHeadings:     tableHeadings,
+		tableHeadingsWide: tableHeadingsWide,
+		headingsMap:       headingsMap,
+		isList:            true,
+	}
+	helpers[tmd] = rh
 }
 
 // Create a new concrete resource structure based on the type.  If the type is
@@ -85,7 +122,7 @@ func newResource(tm unversioned.TypeMetadata) (unversioned.Resource, error) {
 	if !ok {
 		return nil, errors.New(fmt.Sprintf("Unknown resource type (%s) and/or version (%s)", tm.Kind, tm.APIVersion))
 	}
-	glog.V(2).Infof("Found resource helper: %s\n", rh)
+	glog.V(2).Infof("Found resource helper: %s\t\n", rh)
 
 	// Create new resource and fill in the type metadata.
 	new := reflect.New(rh.resourceType)
@@ -128,7 +165,7 @@ func createResourcesFromBytes(b []byte) ([]unversioned.Resource, error) {
 // Return as a slice of Resource interfaces, containing a single element that is
 // the unmarshalled resource.
 func unmarshalResource(tm unversioned.TypeMetadata, b []byte) ([]unversioned.Resource, error) {
-	glog.V(2).Infof("Processing type %s\n", tm.Kind)
+	glog.V(2).Infof("Processing type %s\t\n", tm.Kind)
 	unpacked, err := newResource(tm)
 	if err != nil {
 		return nil, err
@@ -138,12 +175,12 @@ func unmarshalResource(tm unversioned.TypeMetadata, b []byte) ([]unversioned.Res
 		return nil, err
 	}
 
-	glog.V(2).Infof("Type of unpacked data: %v\n", reflect.TypeOf(unpacked))
+	glog.V(2).Infof("Type of unpacked data: %v\t\n", reflect.TypeOf(unpacked))
 	if err = validator.Validate(unpacked); err != nil {
 		return nil, err
 	}
 
-	glog.V(2).Infof("Unpacked: %+v\n", unpacked)
+	glog.V(2).Infof("Unpacked: %+v\t\n", unpacked)
 
 	return []unversioned.Resource{unpacked}, nil
 }
@@ -154,10 +191,10 @@ func unmarshalResource(tm unversioned.TypeMetadata, b []byte) ([]unversioned.Res
 // Return as a slice of Resource interfaces, containing an element that is each of
 // the unmarshalled resources.
 func unmarshalSliceOfResources(tml []unversioned.TypeMetadata, b []byte) ([]unversioned.Resource, error) {
-	glog.V(2).Infof("Processing list of resources\n")
+	glog.V(2).Infof("Processing list of resources\t\n")
 	unpacked := make([]unversioned.Resource, len(tml))
 	for i, tm := range tml {
-		glog.V(2).Infof("  - processing type %s\n", tm.Kind)
+		glog.V(2).Infof("  - processing type %s\t\n", tm.Kind)
 		r, err := newResource(tm)
 		if err != nil {
 			return nil, err
@@ -177,7 +214,7 @@ func unmarshalSliceOfResources(tml []unversioned.TypeMetadata, b []byte) ([]unve
 		}
 	}
 
-	glog.V(2).Infof("Unpacked: %+v\n", unpacked)
+	glog.V(2).Infof("Unpacked: %+v\t\n", unpacked)
 
 	return unpacked, nil
 }
@@ -190,7 +227,6 @@ func unmarshalSliceOfResources(tml []unversioned.TypeMetadata, b []byte) ([]unve
 // The returned Resource will either be a single Resource or a List containing zero or more
 // Resources.  If the file does not contain any valid Resources this function returns an error.
 func CreateResourcesFromFile(f string) ([]unversioned.Resource, error) {
-
 	// Load the bytes from file or from stdin.
 	var b []byte
 	var err error
@@ -205,4 +241,99 @@ func CreateResourcesFromFile(f string) ([]unversioned.Resource, error) {
 	}
 
 	return createResourcesFromBytes(b)
+}
+
+// Implement the ResourceManager interface on the resourceHelper struct.
+
+// GetTableDefaultHeadings returns the default headings to use in the ps-style get output
+// for the resource.  Wide indicates whether the wide (true) or concise (false) column set is
+// required.
+func (rh resourceHelper) GetTableDefaultHeadings(wide bool) []string {
+	if wide {
+		return rh.tableHeadingsWide
+	} else {
+		return rh.tableHeadings
+	}
+}
+
+// GetTableTemplate constructs the go-lang template string from the supplied set of headings.
+// The template separates columns using tabs so that a tabwriter can be used to pretty-print
+// the table.
+func (rh resourceHelper) GetTableTemplate(headings []string) (string, error) {
+	// Write the headings line.
+	buf := new(bytes.Buffer)
+	for _, heading := range headings {
+		buf.WriteString(heading)
+		buf.WriteByte('\t')
+	}
+	buf.WriteByte('\n')
+
+	// If this is a list type, we need to iterate over the list items.
+	if rh.isList {
+		buf.WriteString("{{range .Items}}")
+	}
+
+	// For each column, add the go-template snippet for the corresponding field value.
+	for _, heading := range headings {
+		value, ok := rh.headingsMap[heading]
+		if !ok {
+			headings := make([]string, 0, len(rh.headingsMap))
+			for heading := range rh.headingsMap {
+				headings = append(headings, heading)
+			}
+			return "", fmt.Errorf("Unknown heading %s, valid values are: %s",
+				heading,
+				strings.Join(headings, ", "))
+		}
+		buf.WriteString(value)
+		buf.WriteByte('\t')
+	}
+	buf.WriteByte('\n')
+
+	// If this is a list, close off the range.
+	if rh.isList {
+		buf.WriteString("{{end}}")
+	}
+
+	return buf.String(), nil
+}
+
+// Apply is an un-typed method to apply (create or update) a resource.  This calls directly
+// through to the resource helper specific Apply method which will map the untyped call to
+// the typed interface on the client.
+func (rh resourceHelper) Apply(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+	return rh.apply(client, resource)
+}
+
+// Create is an un-typed method to create a new resource.  This calls directly
+// through to the resource helper specific Create method which will map the untyped call to
+// the typed interface on the client.
+func (rh resourceHelper) Create(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+	return rh.create(client, resource)
+}
+
+// Update is an un-typed method to update an existing resource.  This calls directly
+// through to the resource helper specific Update method which will map the untyped call to
+// the typed interface on the client.
+func (rh resourceHelper) Update(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+	return rh.update(client, resource)
+}
+
+// Delete is an un-typed method to delete an existing resource.  This calls directly
+// through to the resource helper specific Delete method which will map the untyped call to
+// the typed interface on the client.
+func (rh resourceHelper) Delete(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+	return rh.delete(client, resource)
+}
+
+// List is an un-typed method to list existing resources.  This calls directly
+// through to the resource helper specific List method which will map the untyped call to
+// the typed interface on the client.
+func (rh resourceHelper) List(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+	return rh.list(client, resource)
+}
+
+// Return the Resource Manager for a particular resource type.
+func GetResourceManager(resource unversioned.Resource) ResourceManager {
+	return helpers[resource.GetTypeMetadata()]
 }

--- a/calicoctl/resourcemgr/tier.go
+++ b/calicoctl/resourcemgr/tier.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemgr
+
+import (
+	"github.com/tigera/libcalico-go/lib/api"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/client"
+)
+
+func init() {
+	registerResource(
+		api.NewTier(),
+		api.NewTierList(),
+		[]string{"NAME", "ORDER"},
+		[]string{"NAME", "ORDER"},
+		map[string]string{
+			"NAME":  "{{.Metadata.Name}}",
+			"ORDER": "{{.Spec.Order}}",
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Tier)
+			return client.Tiers().Apply(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Tier)
+			return client.Tiers().Create(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Tier)
+			return client.Tiers().Update(&r)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Tier)
+			return nil, client.Tiers().Delete(r.Metadata)
+		},
+		func(client *client.Client, resource unversioned.Resource) (unversioned.Resource, error) {
+			r := resource.(api.Tier)
+			return client.Tiers().List(r.Metadata)
+		},
+	)
+}


### PR DESCRIPTION
This PR adds a number of different output options to the `calicoctl get` command.  This includes:
-  PS style output (now the default)
-  Wide PS style output (i.e. more columns)
-  Custom headings PS style output (user can choose from any column that has been defined)
-  Custom golang template
-  Custom golang template file
-  JSON

As part of this work, I've added more functionality to the resource manager to tidy up the resource-specific code that was littered around calicoctl.  Now the resource manager has all of the resource-specific mappings to provide all resource management actions (apply, create etc.).