### PR TITLE
Allow plural and case-insensitive resource names on CLI

### DIFF
--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -92,30 +92,35 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 	tier := stringOrBlank("--tier")
 	hostname := stringOrBlank("--hostname")
 	resScope := stringOrBlank("--scope")
-	switch kind {
-	case "hostEndpoint":
+	switch strings.ToLower(kind) {
+	case "hostendpoints":
+		fallthrough
+	case "hostendpoint":
 		h := api.NewHostEndpoint()
 		h.Metadata.Name = name
 		h.Metadata.Hostname = hostname
 		return *h, nil
-	case "workloadEndpoint":
-		h := api.NewWorkloadEndpoint() //TODO Need to add orchestrator ID and workload ID
-		h.Metadata.Name = name
-		h.Metadata.Hostname = hostname
-		return *h, nil
+	case "tiers":
+		fallthrough
 	case "tier":
 		t := api.NewTier()
 		t.Metadata.Name = name
 		return *t, nil
+	case "profiles":
+		fallthrough
 	case "profile":
 		p := api.NewProfile()
 		p.Metadata.Name = name
 		return *p, nil
+	case "policies":
+		fallthrough
 	case "policy":
 		p := api.NewPolicy()
 		p.Metadata.Name = name
 		p.Metadata.Tier = tier
 		return *p, nil
+	case "pools":
+		fallthrough
 	case "pool":
 		p := api.NewPool()
 		if name != "" {
@@ -126,7 +131,9 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 			p.Metadata.CIDR = *cidr
 		}
 		return *p, nil
-	case "bgpPeer":
+	case "bgppeers":
+		fallthrough
+	case "bgppeer":
 		p := api.NewBGPPeer()
 		if name != "" {
 			err := p.Metadata.PeerIP.UnmarshalText([]byte(name))


### PR DESCRIPTION
PR to allow case-insensitive and plural versions of resource names in the CLI.  This does not change the format required in the YAML or JSON files - these are still case sensitive and only accept the singular versions.

Fixes #43 
