### PR TITLE
Wrong error message for missing resource type

### DIFF
--- a/calicoctl/commands/resources.go
+++ b/calicoctl/commands/resources.go
@@ -155,7 +155,7 @@ func getResourceFromArguments(args map[string]interface{}) (unversioned.Resource
 		return *p, nil
 
 	default:
-		return nil, fmt.Errorf("Resource type '%s' is not unsupported", kind)
+		return nil, fmt.Errorf("Resource type '%s' is not supported", kind)
 	}
 }
 


### PR DESCRIPTION
This fixes issue [97](https://github.com/tigera/libcalico-go/issues/97)

**Before**: 
```bash
./bin/calicoctl get foo
Error getting resources: Resource type 'foo' is not unsupported
```

**After**:
```bash
./bin/calicoctl get foo
Error getting resources: Resource type 'foo' is not supported
```