### PR TITLE
Try to improve backend API

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
 hash: 1a696e4d1f4b30ceb1b1305d8baeb4201a10aa006f78ca8024b838896f6f2901
-updated: 2016-08-12T10:34:11.659733358-07:00
+updated: 2016-08-25T11:04:21.23689082+01:00
 imports:
 - name: github.com/cloudfoundry-incubator/candiedyaml
   version: 99c3df83b51532e3615f851d8c2dbb638f5313bf
 - name: github.com/coreos/etcd
-  version: 1ba7bb237fd54884381c7d4d46d78010d7aac2ad
+  version: 488ae52a5190fbf24539e281f13b461b1ac35df4
   subpackages:
   - client
   - pkg/transport
@@ -13,11 +13,13 @@ imports:
   - pkg/fileutil
   - pkg/tlsutil
 - name: github.com/coreos/go-systemd
-  version: d4039021cfc2d0ea21d34afda21631314e83f75a
+  version: bfdc81d0d7e0fb19447b08571f63b774495251ce
   subpackages:
+  - daemon
   - journal
+  - util
 - name: github.com/coreos/pkg
-  version: a48e304ff9331be6d5df352b6b47bd1395ab5dd7
+  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
   subpackages:
   - capnslog
 - name: github.com/docopt/docopt-go
@@ -27,17 +29,21 @@ imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/kelseyhightower/envconfig
-  version: 91921eb4cf999321cdbeebdba5a03555800d493b
+  version: 1e291572dcb9ba673cdcdb15e0f422702415ebaf
 - name: github.com/satori/go.uuid
   version: 0aa62d5ddceb50dbcb909d790b5345affd3669b6
 - name: github.com/ugorji/go
-  version: b94837a2404ab90efe9289e77a70694c355739cb
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
 - name: golang.org/x/net
-  version: a728288923b47049b2ce791836767ffbe964a5bd
+  version: 6acef71eb69611914f7a30939ea9f6e194c78172
   subpackages:
   - context
 - name: gopkg.in/go-playground/validator.v8
-  version: 7a080ada5ba072a91fd7f677bcf4d0e1aa286d39
-devImports: []
+  version: 5f57d2222ad794d0dffb07e664ea05e2ee07d60c
+- name: gopkg.in/tchap/go-patricia.v2
+  version: 666120de432aea38ab06bd5c818f04f4129882c9
+  subpackages:
+  - patricia
+testImports: []

--- a/lib/backend/api/api.go
+++ b/lib/backend/api/api.go
@@ -15,8 +15,40 @@
 package api
 
 import (
+	"fmt"
 	. "github.com/tigera/libcalico-go/lib/backend/model"
 )
+
+// SyncStatus represents the overall state of the datastore.
+// When the status changes, the Syncer calls OnStatusUpdated() on its callback.
+type SyncStatus uint8
+
+const (
+	// WaitForDatastore means the Syncer is waiting to connect to the datastore.
+	// (Or, it is waiting for the data in the datastore to be ready to use.)
+	WaitForDatastore SyncStatus = iota
+	// ResyncInProgress means the Syncer is resyncing with the datastore.
+	// During the first resync, the Syncer sends updates for all keys that
+	// exist in the datastore as well as any updates that occur
+	// concurrently.
+	ResyncInProgress
+	// InSync means the Syncer has now sent all the existing keys in the
+	// datastore and the user of hte API has the full picture.
+	InSync
+)
+
+func (s SyncStatus) String() string {
+	switch s {
+	case WaitForDatastore:
+		return "wait-for-ready"
+	case InSync:
+		return "in-sync"
+	case ResyncInProgress:
+		return "resync"
+	default:
+		return fmt.Sprintf("Unknown<%v>", uint8(s))
+	}
+}
 
 type Client interface {
 	Create(object *KVPair) (*KVPair, error)
@@ -25,4 +57,27 @@ type Client interface {
 	Delete(object *KVPair) error
 	Get(key Key) (*KVPair, error)
 	List(list ListInterface) ([]*KVPair, error)
+
+	// Syncer creates an object that generates a series of KVPair updates,
+	// which paint an eventually-consistent picture of the full state of
+	// the datastore and then generates subsequent KVPair updates for
+	// changes to the datastore.
+	Syncer(callbacks SyncerCallbacks) Syncer
+}
+
+type Syncer interface {
+	Start()
+}
+
+type SyncerCallbacks interface {
+	OnStatusUpdated(status SyncStatus)
+	// OnUpdates is called when the Syncer has one or more updates to report.
+	// Updates consist of typed key-value pairs.  The keys are drawn from the
+	// backend.model package.  The values are either nil, to indicate a
+	// deletion, or a pointer to a value of the associated value type.
+	OnUpdates(updates []KVPair)
+}
+
+type SyncerParseFailCallbacks interface {
+	ParseFailed(rawKey string, rawValue *string)
 }

--- a/lib/backend/compat/compat.go
+++ b/lib/backend/compat/compat.go
@@ -126,6 +126,10 @@ func (c *ModelAdaptor) List(l ListInterface) ([]*KVPair, error) {
 	return c.client.List(l)
 }
 
+func (c *ModelAdaptor) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	return c.client.Syncer(callbacks)
+}
+
 // Convert a Profile KVPair to separate KVPair types for Keys, Labels and Rules.
 // These separate KVPairs are used to write three separate objects that make up
 // a single profile.

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -132,7 +132,7 @@ func (c *EtcdClient) Apply(d *KVPair) (*KVPair, error) {
 
 // Delete an entry in the datastore.  This errors if the entry does not exists.
 func (c *EtcdClient) Delete(d *KVPair) error {
-	key, err := d.Key.DefaultDeletePath()
+	key, err := KeyToDefaultDeletePath(d.Key)
 	if err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func (c *EtcdClient) Delete(d *KVPair) error {
 
 // Get an entry from the datastore.  This errors if the entry does not exist.
 func (c *EtcdClient) Get(k Key) (*KVPair, error) {
-	key, err := k.DefaultPath()
+	key, err := KeyToDefaultPath(k)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (c *EtcdClient) Get(k Key) (*KVPair, error) {
 func (c *EtcdClient) List(l ListInterface) ([]*KVPair, error) {
 	// To list entries, we enumerate from the common root based on the supplied
 	// IDs, and then filter the results.
-	key := l.DefaultPathRoot()
+	key := ListOptionsToDefaultPathRoot(l)
 	glog.V(2).Infof("List Key: %s\n", key)
 	if results, err := c.etcdKeysAPI.Get(context.Background(), key, etcdListOpts); err != nil {
 		// If the root key does not exist - that's fine, return no list entries.
@@ -195,7 +195,7 @@ func (c *EtcdClient) List(l ListInterface) ([]*KVPair, error) {
 // Set an existing entry in the datastore.  This ignores whether an entry already
 // exists.
 func (c *EtcdClient) set(d *KVPair, options *etcd.SetOptions) (*KVPair, error) {
-	key, err := d.Key.DefaultPath()
+	key, err := KeyToDefaultPath(d.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func filterEtcdList(n *etcd.Node, l ListInterface) []*KVPair {
 		for _, node := range n.Nodes {
 			kvs = append(kvs, filterEtcdList(node, l)...)
 		}
-	} else if k := l.ParseDefaultKey(n.Key); k != nil {
+	} else if k := l.KeyFromDefaultPath(n.Key); k != nil {
 		if object, err := ParseValue(k, []byte(n.Value)); err == nil {
 			if reflect.ValueOf(object).Kind() == reflect.Ptr {
 				// Unwrap any pointers.

--- a/lib/backend/etcd/etcd.go
+++ b/lib/backend/etcd/etcd.go
@@ -26,6 +26,7 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/golang/glog"
+	"github.com/tigera/libcalico-go/lib/backend/api"
 	. "github.com/tigera/libcalico-go/lib/backend/model"
 	"github.com/tigera/libcalico-go/lib/errors"
 	"golang.org/x/net/context"
@@ -100,6 +101,10 @@ func NewEtcdClient(config *EtcdConfig) (*EtcdClient, error) {
 	keys := etcd.NewKeysAPI(client)
 
 	return &EtcdClient{etcdClient: client, etcdKeysAPI: keys}, nil
+}
+
+func (c *EtcdClient) Syncer(callbacks api.SyncerCallbacks) api.Syncer {
+	return newSyncer(c.etcdKeysAPI, callbacks)
 }
 
 // Create an entry in the datastore.  This errors if the entry already exists.

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -1,0 +1,341 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"github.com/coreos/etcd/client"
+	etcd "github.com/coreos/etcd/client"
+	"github.com/golang/glog"
+	"github.com/tigera/libcalico-go/lib/hwm"
+	"github.com/tigera/libcalico-go/lib/backend/api"
+	"github.com/tigera/libcalico-go/lib/backend/model"
+	"golang.org/x/net/context"
+	"time"
+)
+
+func newSyncer(keysAPI etcd.KeysAPI, callbacks api.SyncerCallbacks) *etcdSyncer {
+	return &etcdSyncer{
+		keysAPI:   keysAPI,
+		callbacks: callbacks,
+	}
+}
+
+type etcdSyncer struct {
+	callbacks api.SyncerCallbacks
+	keysAPI   etcd.KeysAPI
+	OneShot   bool
+}
+
+func (syn *etcdSyncer) Start() {
+	// Start a background thread to read events from etcd.  It will
+	// queue events onto the etcdEvents channel.  If it drops out of sync,
+	// it will signal on the resyncIndex channel.
+	glog.Info("Starting etcd Syncer")
+	etcdEvents := make(chan event, 20000)
+	triggerResync := make(chan uint64, 5)
+	initialSnapshotIndex := make(chan uint64)
+	if !syn.OneShot {
+		glog.Info("Syncer not in one-shot mode, starting watcher thread")
+		go syn.watchEtcd(etcdEvents, triggerResync, initialSnapshotIndex)
+	}
+
+	// Start a background thread to read snapshots from etcd.  It will
+	// read a start-of-day snapshot and then wait to be signalled on the
+	// resyncIndex channel.
+	snapshotUpdates := make(chan event)
+	go syn.readSnapshotsFromEtcd(snapshotUpdates, triggerResync, initialSnapshotIndex)
+	go syn.mergeUpdates(snapshotUpdates, etcdEvents)
+}
+
+const (
+	actionSet uint8 = iota
+	actionDel
+	actionSnapFinished
+)
+
+// TODO Split this into different types of struct and use a type-switch to unpack.
+type event struct {
+	action           uint8
+	modifiedIndex    uint64
+	snapshotIndex    uint64
+	key              string
+	value            string
+	snapshotStarting bool
+	snapshotFinished bool
+}
+
+func (syn *etcdSyncer) readSnapshotsFromEtcd(snapshotUpdates chan<- event, triggerResync <-chan uint64, initialSnapshotIndex chan<- uint64) {
+	glog.Info("Syncer snapshot-reading thread started")
+	getOpts := client.GetOptions{
+		Recursive: true,
+		Sort:      false,
+		Quorum:    false,
+	}
+	var highestSnapshotIndex uint64
+	var minIndex uint64
+
+	for {
+		if highestSnapshotIndex > 0 {
+			// Wait for the watcher thread to tell us what index
+			// it starts from.  We need to load a snapshot with
+			// an equal or later index, otherwise we could miss
+			// some updates.  (Since we may connect to a follower
+			// server, it's possible, if unlikely, for us to read
+			// a stale snapshot.)
+			minIndex = <-triggerResync
+			glog.Infof("Asked for snapshot > %v; last snapshot was %v",
+				minIndex, highestSnapshotIndex)
+			if highestSnapshotIndex >= minIndex {
+				// We've already read a newer snapshot, no
+				// need to re-read.
+				glog.Info("Snapshot already new enough")
+				continue
+			}
+		}
+
+	readRetryLoop:
+		for {
+			resp, err := syn.keysAPI.Get(context.Background(),
+				"/calico/v1", &getOpts)
+			if err != nil {
+				if syn.OneShot {
+					// One-shot mode is used to grab a snapshot and then
+					// stop.  We don't want to go into a retry loop.
+					glog.Fatal("Failed to read snapshot from etcd: ", err)
+				}
+				glog.Warning("Error getting snapshot, retrying...", err)
+				time.Sleep(1 * time.Second)
+				continue readRetryLoop
+			}
+
+			if resp.Index < minIndex {
+				glog.Info("Retrieved stale snapshot, rereading...")
+				continue readRetryLoop
+			}
+
+			// If we get here, we should have a good
+			// snapshot.  Send it to the merge thread.
+			sendNode(resp.Node, snapshotUpdates, resp)
+			snapshotUpdates <- event{
+				action:        actionSnapFinished,
+				snapshotIndex: resp.Index,
+			}
+			if resp.Index > highestSnapshotIndex {
+				if highestSnapshotIndex == 0 {
+					initialSnapshotIndex <- resp.Index
+					close(initialSnapshotIndex)
+				}
+				highestSnapshotIndex = resp.Index
+			}
+			break readRetryLoop
+		}
+	}
+}
+
+func sendNode(node *client.Node, snapshotUpdates chan<- event, resp *client.Response) {
+	if !node.Dir {
+		snapshotUpdates <- event{
+			key:           node.Key,
+			modifiedIndex: node.ModifiedIndex,
+			snapshotIndex: resp.Index,
+			value:         node.Value,
+			action:        actionSet,
+		}
+	} else {
+		for _, child := range node.Nodes {
+			sendNode(child, snapshotUpdates, resp)
+		}
+	}
+}
+
+func (syn *etcdSyncer) watchEtcd(etcdEvents chan<- event, triggerResync chan<- uint64, initialSnapshotIndex <-chan uint64) {
+	start_index := <-initialSnapshotIndex
+
+	watcherOpts := client.WatcherOptions{
+		AfterIndex: start_index + 1,
+		Recursive:  true,
+	}
+	watcher := syn.keysAPI.Watcher("/calico/v1", &watcherOpts)
+	inSync := true
+	for {
+		resp, err := watcher.Next(context.Background())
+		if err != nil {
+			switch err := err.(type) {
+			case client.Error:
+				errCode := err.Code
+				if errCode == client.ErrorCodeWatcherCleared ||
+					errCode == client.ErrorCodeEventIndexCleared {
+					glog.Warning("Lost sync with etcd, restarting watcher")
+					watcherOpts.AfterIndex = 0
+					watcher = syn.keysAPI.Watcher("/calico/v1",
+						&watcherOpts)
+					inSync = false
+					// FIXME, we'll only trigger a resync after the next event
+					continue
+				} else {
+					glog.Error("Error from etcd", err)
+					time.Sleep(1 * time.Second)
+				}
+			case *client.ClusterError:
+				glog.Error("Cluster error from etcd", err)
+				time.Sleep(1 * time.Second)
+			default:
+				panic(err)
+			}
+		} else {
+			var actionType uint8
+			switch resp.Action {
+			case "set", "compareAndSwap", "update", "create":
+				actionType = actionSet
+			case "delete", "compareAndDelete", "expire":
+				actionType = actionDel
+			default:
+				panic("Unknown action type")
+			}
+
+			node := resp.Node
+			if node.Dir && actionType == actionSet {
+				// Creation of a directory, we don't care.
+				continue
+			}
+			if !inSync {
+				// Tell the snapshot thread that we need a
+				// new snapshot.  The snapshot needs to be
+				// from our index or one lower.
+				snapIdx := node.ModifiedIndex - 1
+				glog.V(1).Infof("Asking for snapshot @ %v",
+					snapIdx)
+				triggerResync <- snapIdx
+				inSync = true
+			}
+			etcdEvents <- event{
+				action:           actionType,
+				modifiedIndex:    node.ModifiedIndex,
+				key:              resp.Node.Key,
+				value:            node.Value,
+				snapshotStarting: !inSync,
+			}
+		}
+	}
+}
+
+func (syn *etcdSyncer) mergeUpdates(snapshotUpdates <-chan event, watcherUpdates <-chan event) {
+	var e event
+	var minSnapshotIndex uint64
+	hwms := hwm.NewHighWatermarkTracker()
+
+	syn.callbacks.OnStatusUpdated(api.WaitForDatastore)
+	for {
+		select {
+		case e = <-snapshotUpdates:
+			glog.V(4).Infof("Snapshot update %v @ %v\n", e.key, e.modifiedIndex)
+		case e = <-watcherUpdates:
+			glog.V(4).Infof("Watcher update %v @ %v\n", e.key, e.modifiedIndex)
+		}
+		if e.snapshotStarting {
+			// Watcher lost sync, need to track deletions until
+			// we get a snapshot from after this index.
+			glog.V(1).Infof("Watcher out-of-sync, starting to track deletions")
+			minSnapshotIndex = e.modifiedIndex
+			syn.callbacks.OnStatusUpdated(api.ResyncInProgress)
+		}
+		switch e.action {
+		case actionSet:
+			var indexToStore uint64
+			if e.snapshotIndex != 0 {
+				// Store the snapshot index in the trie so that
+				// we can scan the trie later looking for
+				// prefixes that are older than the snapshot
+				// (and hence must have been deleted while
+				// we were out-of-sync).
+				indexToStore = e.snapshotIndex
+			} else {
+				indexToStore = e.modifiedIndex
+			}
+			oldIdx := hwms.StoreUpdate(e.key, indexToStore)
+			//glog.V(2).Infof("%v update %v -> %v\n",
+			//	e.key, oldIdx, e.modifiedIndex)
+			if oldIdx < e.modifiedIndex {
+				// Event is newer than value for that key.
+				// Send the update to Felix.
+				syn.sendUpdate(e.key, &e.value, e.modifiedIndex)
+			}
+		case actionDel:
+			deletedKeys := hwms.StoreDeletion(e.key,
+				e.modifiedIndex)
+			glog.V(3).Infof("Prefix %v deleted; %v keys",
+				e.key, len(deletedKeys))
+			syn.sendDeletions(deletedKeys, e.modifiedIndex)
+		case actionSnapFinished:
+			if e.snapshotIndex >= minSnapshotIndex {
+				// Now in sync.
+				hwms.StopTrackingDeletions()
+				deletedKeys := hwms.DeleteOldKeys(e.snapshotIndex)
+				glog.Infof("Snapshot finished at index %v; "+
+					"%v keys deleted in cleanup.\n",
+					e.snapshotIndex, len(deletedKeys))
+				syn.sendDeletions(deletedKeys, e.snapshotIndex)
+			}
+			syn.callbacks.OnStatusUpdated(api.InSync)
+		}
+	}
+}
+
+func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64) {
+	glog.V(4).Infof("Parsing etcd key %#v", key)
+	parsedKey := model.ParseKey(key)
+	if parsedKey == nil {
+		glog.V(3).Infof("Failed to parse key %v", key)
+		if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {
+			cb.ParseFailed(key, value)
+		}
+		return
+	}
+	glog.V(4).Infof("Parsed etcd key: %v", parsedKey)
+
+	var parsedValue interface{}
+	var err error
+	if value != nil {
+		parsedValue, err = model.ParseValue(parsedKey, []byte(*value))
+		if err != nil {
+			glog.Warningf("Failed to parse value for %v: %#v", key, *value)
+		}
+		glog.V(4).Infof("Parsed value: %#v", parsedValue)
+	}
+	updates := []model.KVPair{
+		{Key: parsedKey, Value: parsedValue, Revision: revision},
+	}
+	syn.callbacks.OnUpdates(updates)
+}
+
+func (syn *etcdSyncer) sendDeletions(deletedKeys []string, revision uint64) {
+	updates := make([]model.KVPair, 0, len(deletedKeys))
+	for _, key := range deletedKeys {
+		parsedKey := model.ParseKey(key)
+		if parsedKey == nil {
+			glog.V(3).Infof("Failed to parse key %v", key)
+			if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {
+				cb.ParseFailed(key, nil)
+			}
+			continue
+		}
+		updates = append(updates, model.KVPair{
+			Key:      parsedKey,
+			Value:    nil,
+			Revision: revision,
+		})
+	}
+	syn.callbacks.OnUpdates(updates)
+}

--- a/lib/backend/etcd/syncer.go
+++ b/lib/backend/etcd/syncer.go
@@ -18,9 +18,9 @@ import (
 	"github.com/coreos/etcd/client"
 	etcd "github.com/coreos/etcd/client"
 	"github.com/golang/glog"
-	"github.com/tigera/libcalico-go/lib/hwm"
 	"github.com/tigera/libcalico-go/lib/backend/api"
 	"github.com/tigera/libcalico-go/lib/backend/model"
+	"github.com/tigera/libcalico-go/lib/hwm"
 	"golang.org/x/net/context"
 	"time"
 )
@@ -295,7 +295,7 @@ func (syn *etcdSyncer) mergeUpdates(snapshotUpdates <-chan event, watcherUpdates
 
 func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64) {
 	glog.V(4).Infof("Parsing etcd key %#v", key)
-	parsedKey := model.ParseKey(key)
+	parsedKey := model.KeyFromDefaultPath(key)
 	if parsedKey == nil {
 		glog.V(3).Infof("Failed to parse key %v", key)
 		if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {
@@ -323,7 +323,7 @@ func (syn *etcdSyncer) sendUpdate(key string, value *string, revision uint64) {
 func (syn *etcdSyncer) sendDeletions(deletedKeys []string, revision uint64) {
 	updates := make([]model.KVPair, 0, len(deletedKeys))
 	for _, key := range deletedKeys {
-		parsedKey := model.ParseKey(key)
+		parsedKey := model.KeyFromDefaultPath(key)
 		if parsedKey == nil {
 			glog.V(3).Infof("Failed to parse key %v", key)
 			if cb, ok := syn.callbacks.(api.SyncerParseFailCallbacks); ok {

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -38,7 +38,7 @@ type BGPPeerKey struct {
 	PeerIP   net.IP      `json:"-" validate:"required"`
 }
 
-func (key BGPPeerKey) DefaultPath() (string, error) {
+func (key BGPPeerKey) defaultPath() (string, error) {
 	if key.PeerIP.IP == nil {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "peerIP"}
 	}
@@ -64,8 +64,8 @@ func (key BGPPeerKey) DefaultPath() (string, error) {
 	}
 }
 
-func (key BGPPeerKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key BGPPeerKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key BGPPeerKey) valueType() reflect.Type {
@@ -86,7 +86,7 @@ type BGPPeerListOptions struct {
 	PeerIP   net.IP
 }
 
-func (options BGPPeerListOptions) DefaultPathRoot() string {
+func (options BGPPeerListOptions) defaultPathRoot() string {
 	switch options.Scope {
 	case scope.Undefined:
 		if options.Hostname == "" {
@@ -119,7 +119,7 @@ func (options BGPPeerListOptions) DefaultPathRoot() string {
 	panic(fmt.Errorf("Unexpected scope value: %d", options.Scope))
 }
 
-func (options BGPPeerListOptions) ParseDefaultKey(ekey string) Key {
+func (options BGPPeerListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get BGPPeer key from %s", ekey)
 	hostname := ""
 	peerIP := net.IP{}

--- a/lib/backend/model/bgppeer.go
+++ b/lib/backend/model/bgppeer.go
@@ -119,11 +119,11 @@ func (options BGPPeerListOptions) defaultPathRoot() string {
 	panic(fmt.Errorf("Unexpected scope value: %d", options.Scope))
 }
 
-func (options BGPPeerListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get BGPPeer key from %s", ekey)
+func (options BGPPeerListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get BGPPeer key from %s", path)
 	hostname := ""
 	peerIP := net.IP{}
-	ekeyb := []byte(ekey)
+	ekeyb := []byte(path)
 	var peerScope scope.Scope
 
 	if r := matchGlobalBGPPeer.FindAllSubmatch(ekeyb, -1); len(r) == 1 {
@@ -134,7 +134,7 @@ func (options BGPPeerListOptions) KeyFromDefaultPath(ekey string) Key {
 		_ = peerIP.UnmarshalText(r[0][2])
 		peerScope = scope.Node
 	} else {
-		glog.V(2).Infof("%s didn't match regex", ekey)
+		glog.V(2).Infof("%s didn't match regex", path)
 		return nil
 	}
 

--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -34,7 +34,7 @@ type BlockKey struct {
 	CIDR net.IPNet `json:"-" validate:"required,name"`
 }
 
-func (key BlockKey) DefaultPath() (string, error) {
+func (key BlockKey) defaultPath() (string, error) {
 	if key.CIDR.IP == nil {
 		return "", errors.ErrorInsufficientIdentifiers{}
 	}
@@ -43,8 +43,8 @@ func (key BlockKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key BlockKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key BlockKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key BlockKey) valueType() reflect.Type {
@@ -55,7 +55,7 @@ type BlockListOptions struct {
 	IPVersion int `json:"-"`
 }
 
-func (options BlockListOptions) DefaultPathRoot() string {
+func (options BlockListOptions) defaultPathRoot() string {
 	k := "/calico/ipam/v2/assignment/"
 	if options.IPVersion != 0 {
 		k = k + fmt.Sprintf("ipv%d/", options.IPVersion)
@@ -63,7 +63,7 @@ func (options BlockListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options BlockListOptions) ParseDefaultKey(ekey string) Key {
+func (options BlockListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get Block key from %s", ekey)
 	r := matchBlock.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/block.go
+++ b/lib/backend/model/block.go
@@ -63,11 +63,11 @@ func (options BlockListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options BlockListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get Block key from %s", ekey)
-	r := matchBlock.FindAllStringSubmatch(ekey, -1)
+func (options BlockListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get Block key from %s", path)
+	r := matchBlock.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
-		glog.V(2).Infof("%s didn't match regex", ekey)
+		glog.V(2).Infof("%s didn't match regex", path)
 		return nil
 	}
 	cidrStr := strings.Replace(r[0][1], "-", "/", 1)

--- a/lib/backend/model/block_affinity.go
+++ b/lib/backend/model/block_affinity.go
@@ -69,11 +69,11 @@ func (options BlockAffinityListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options BlockAffinityListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get Block affinity key from %s", ekey)
-	r := matchBlockAffinity.FindAllStringSubmatch(ekey, -1)
+func (options BlockAffinityListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get Block affinity key from %s", path)
+	r := matchBlockAffinity.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
-		glog.V(2).Infof("%s didn't match regex", ekey)
+		glog.V(2).Infof("%s didn't match regex", path)
 		return nil
 	}
 	cidrStr := strings.Replace(r[0][2], "-", "/", 1)

--- a/lib/backend/model/block_affinity.go
+++ b/lib/backend/model/block_affinity.go
@@ -35,7 +35,7 @@ type BlockAffinityKey struct {
 	Host string    `json:"-"`
 }
 
-func (key BlockAffinityKey) DefaultPath() (string, error) {
+func (key BlockAffinityKey) defaultPath() (string, error) {
 	if key.CIDR.IP == nil || key.Host == "" {
 		return "", errors.ErrorInsufficientIdentifiers{}
 	}
@@ -44,8 +44,8 @@ func (key BlockAffinityKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key BlockAffinityKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key BlockAffinityKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key BlockAffinityKey) valueType() reflect.Type {
@@ -57,7 +57,7 @@ type BlockAffinityListOptions struct {
 	IPVersion int
 }
 
-func (options BlockAffinityListOptions) DefaultPathRoot() string {
+func (options BlockAffinityListOptions) defaultPathRoot() string {
 	k := "/calico/ipam/v2/host/"
 	if options.Host != "" {
 		k = k + options.Host
@@ -69,7 +69,7 @@ func (options BlockAffinityListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options BlockAffinityListOptions) ParseDefaultKey(ekey string) Key {
+func (options BlockAffinityListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get Block affinity key from %s", ekey)
 	r := matchBlockAffinity.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/config.go
+++ b/lib/backend/model/config.go
@@ -85,9 +85,9 @@ func (options GlobalConfigListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options GlobalConfigListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get GlobalConfig key from %s", ekey)
-	r := matchGlobalConfig.FindAllStringSubmatch(ekey, -1)
+func (options GlobalConfigListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get GlobalConfig key from %s", path)
+	r := matchGlobalConfig.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil
@@ -147,9 +147,9 @@ func (options HostConfigListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options HostConfigListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get HostConfig key from %s", ekey)
-	r := matchHostConfig.FindAllStringSubmatch(ekey, -1)
+func (options HostConfigListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get HostConfig key from %s", path)
+	r := matchHostConfig.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil

--- a/lib/backend/model/config.go
+++ b/lib/backend/model/config.go
@@ -35,12 +35,12 @@ var (
 type ReadyFlagKey struct {
 }
 
-func (key ReadyFlagKey) DefaultPath() (string, error) {
+func (key ReadyFlagKey) defaultPath() (string, error) {
 	return "/calico/v1/Ready", nil
 }
 
-func (key ReadyFlagKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key ReadyFlagKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key ReadyFlagKey) valueType() reflect.Type {
@@ -51,12 +51,12 @@ type GlobalConfigKey struct {
 	Name string `json:"-" validate:"required,name"`
 }
 
-func (key GlobalConfigKey) DefaultPath() (string, error) {
-	k, err := key.DefaultDeletePath()
+func (key GlobalConfigKey) defaultPath() (string, error) {
+	k, err := key.defaultDeletePath()
 	return k + "/metadata", err
 }
 
-func (key GlobalConfigKey) DefaultDeletePath() (string, error) {
+func (key GlobalConfigKey) defaultDeletePath() (string, error) {
 	if key.Name == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
@@ -76,7 +76,7 @@ type GlobalConfigListOptions struct {
 	Name string
 }
 
-func (options GlobalConfigListOptions) DefaultPathRoot() string {
+func (options GlobalConfigListOptions) defaultPathRoot() string {
 	k := "/calico/v1/config"
 	if options.Name == "" {
 		return k
@@ -85,7 +85,7 @@ func (options GlobalConfigListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options GlobalConfigListOptions) ParseDefaultKey(ekey string) Key {
+func (options GlobalConfigListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get GlobalConfig key from %s", ekey)
 	r := matchGlobalConfig.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {
@@ -105,12 +105,12 @@ type HostConfigKey struct {
 	Name     string `json:"-" validate:"required,name"`
 }
 
-func (key HostConfigKey) DefaultPath() (string, error) {
-	k, err := key.DefaultDeletePath()
+func (key HostConfigKey) defaultPath() (string, error) {
+	k, err := key.defaultDeletePath()
 	return k + "/metadata", err
 }
 
-func (key HostConfigKey) DefaultDeletePath() (string, error) {
+func (key HostConfigKey) defaultDeletePath() (string, error) {
 	if key.Name == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
@@ -134,7 +134,7 @@ type HostConfigListOptions struct {
 	Name     string
 }
 
-func (options HostConfigListOptions) DefaultPathRoot() string {
+func (options HostConfigListOptions) defaultPathRoot() string {
 	k := "/calico/v1/host"
 	if options.Hostname == "" {
 		return k
@@ -147,7 +147,7 @@ func (options HostConfigListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options HostConfigListOptions) ParseDefaultKey(ekey string) Key {
+func (options HostConfigListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get HostConfig key from %s", ekey)
 	r := matchHostConfig.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -78,9 +78,9 @@ func (options HostEndpointListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options HostEndpointListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get HostEndpoint key from %s", ekey)
-	r := matchHostEndpoint.FindAllStringSubmatch(ekey, -1)
+func (options HostEndpointListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get HostEndpoint key from %s", path)
+	r := matchHostEndpoint.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil

--- a/lib/backend/model/hostendpoint.go
+++ b/lib/backend/model/hostendpoint.go
@@ -36,7 +36,7 @@ type HostEndpointKey struct {
 	EndpointID string `json:"-" validate:"required,hostname"`
 }
 
-func (key HostEndpointKey) DefaultPath() (string, error) {
+func (key HostEndpointKey) defaultPath() (string, error) {
 	if key.Hostname == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
 	}
@@ -48,8 +48,8 @@ func (key HostEndpointKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key HostEndpointKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key HostEndpointKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key HostEndpointKey) valueType() reflect.Type {
@@ -65,7 +65,7 @@ type HostEndpointListOptions struct {
 	EndpointID string
 }
 
-func (options HostEndpointListOptions) DefaultPathRoot() string {
+func (options HostEndpointListOptions) defaultPathRoot() string {
 	k := "/calico/v1/host"
 	if options.Hostname == "" {
 		return k
@@ -78,7 +78,7 @@ func (options HostEndpointListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options HostEndpointListOptions) ParseDefaultKey(ekey string) Key {
+func (options HostEndpointListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get HostEndpoint key from %s", ekey)
 	r := matchHostEndpoint.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/hostip.go
+++ b/lib/backend/model/hostip.go
@@ -30,13 +30,13 @@ type HostIPKey struct {
 	Hostname string
 }
 
-func (key HostIPKey) DefaultPath() (string, error) {
+func (key HostIPKey) defaultPath() (string, error) {
 	return fmt.Sprintf("/calico/v1/host/%s/bird_ip",
 		key.Hostname), nil
 }
 
-func (key HostIPKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key HostIPKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key HostIPKey) valueType() reflect.Type {

--- a/lib/backend/model/ipam_config.go
+++ b/lib/backend/model/ipam_config.go
@@ -27,11 +27,11 @@ var (
 type IPAMConfigKey struct {
 }
 
-func (key IPAMConfigKey) DefaultPath() (string, error) {
+func (key IPAMConfigKey) defaultPath() (string, error) {
 	return "/calico/ipam/v2/config", nil
 }
 
-func (key IPAMConfigKey) DefaultDeletePath() (string, error) {
+func (key IPAMConfigKey) defaultDeletePath() (string, error) {
 	return "", errors.ErrorResourceUpdateConflict{"Cannot delete IPAMConfig"}
 }
 

--- a/lib/backend/model/ipam_handle.go
+++ b/lib/backend/model/ipam_handle.go
@@ -58,11 +58,11 @@ func (options IPAMHandleListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options IPAMHandleListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get IPAM handle key from %s", ekey)
-	r := matchBlock.FindAllStringSubmatch(ekey, -1)
+func (options IPAMHandleListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get IPAM handle key from %s", path)
+	r := matchBlock.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
-		glog.V(2).Infof("%s didn't match regex", ekey)
+		glog.V(2).Infof("%s didn't match regex", path)
 		return nil
 	}
 	return IPAMHandleKey{HandleID: r[0][1]}

--- a/lib/backend/model/ipam_handle.go
+++ b/lib/backend/model/ipam_handle.go
@@ -32,7 +32,7 @@ type IPAMHandleKey struct {
 	HandleID string `json:"id"`
 }
 
-func (key IPAMHandleKey) DefaultPath() (string, error) {
+func (key IPAMHandleKey) defaultPath() (string, error) {
 	if key.HandleID == "" {
 		return "", errors.ErrorInsufficientIdentifiers{}
 	}
@@ -40,8 +40,8 @@ func (key IPAMHandleKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key IPAMHandleKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key IPAMHandleKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key IPAMHandleKey) valueType() reflect.Type {
@@ -52,13 +52,13 @@ type IPAMHandleListOptions struct {
 	// TODO: Have some options here?
 }
 
-func (options IPAMHandleListOptions) DefaultPathRoot() string {
+func (options IPAMHandleListOptions) defaultPathRoot() string {
 	k := "/calico/ipam/v2/handle/"
 	// TODO: Allow filtering on individual host?
 	return k
 }
 
-func (options IPAMHandleListOptions) ParseDefaultKey(ekey string) Key {
+func (options IPAMHandleListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get IPAM handle key from %s", ekey)
 	r := matchBlock.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/ipam_host.go
+++ b/lib/backend/model/ipam_host.go
@@ -28,7 +28,7 @@ type IPAMHostKey struct {
 	Host string
 }
 
-func (key IPAMHostKey) DefaultPath() (string, error) {
+func (key IPAMHostKey) defaultPath() (string, error) {
 	if key.Host == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "host"}
 	}
@@ -37,8 +37,8 @@ func (key IPAMHostKey) DefaultPath() (string, error) {
 	return k, nil
 }
 
-func (key IPAMHostKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key IPAMHostKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key IPAMHostKey) valueType() reflect.Type {

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -43,6 +43,7 @@ type ListInterface interface {
 	// to the directory containing all the keys to be listed.
 	defaultPathRoot() string
 
+	// BUG(smc) I think we should remove this and use the package KeyFromDefaultPath function.
 	// KeyFromDefaultPath parses the default path representation of the
 	// Key type for this list.  It returns nil if passed a different kind
 	// of path.

--- a/lib/backend/model/keys.go
+++ b/lib/backend/model/keys.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"encoding/json"
-	"errors"
 	"reflect"
 	"strings"
 
@@ -33,37 +32,110 @@ var rawBoolType = reflect.TypeOf(rawBool(true))
 
 // Key represents a parsed datastore key.
 type Key interface {
-	// DefaultPath() returns a default stringified path for this object,
-	// suitable for use in most datastores (and used on the Felix API,
-	// for example).
-	DefaultPath() (string, error)
-	// DefaultDeletePath() returns a default stringified path for deleting
-	// this object.
-	DefaultDeletePath() (string, error)
+	defaultPath() (string, error)
+	defaultDeletePath() (string, error)
 	valueType() reflect.Type
 }
 
 // Interface used to perform datastore lookups.
 type ListInterface interface {
-	// DefaultPathRoot() returns a default stringified root path, i.e. path
+	// defaultPathRoot() returns a default stringified root path, i.e. path
 	// to the directory containing all the keys to be listed.
-	DefaultPathRoot() string
-	ParseDefaultKey(key string) Key
+	defaultPathRoot() string
+
+	// KeyFromDefaultPath parses the default path representation of the
+	// Key type for this list.  It returns nil if passed a different kind
+	// of path.
+	KeyFromDefaultPath(key string) Key
 }
 
-// KVPair holds a parsed key and value as well as datastore specific revision
-// information.
+// KVPair holds a typed key and value struct as well as datastore specific
+// revision information.
 type KVPair struct {
 	Key      Key
 	Value    interface{}
 	Revision interface{}
 }
 
-// ParseKey parses a datastore key into one of the <Type>Key structs.
-// Returns nil if the string doesn't match one of our objects.
-func ParseKey(key string) Key {
-	glog.V(4).Infof("Parsing key %v", key)
-	if m := matchWorkloadEndpoint.FindStringSubmatch(key); m != nil {
+// KeyToDefaultPath converts one of the Keys from this package into a unique
+// '/'-delimited path, which is suitable for use as the key when storing the
+// value in a hierarchical (i.e. one with directories and leaves) key/value
+// datastore such as etcd v2.
+//
+// Each unique key returns a unique path.
+//
+// Keys with a hierarchical relationship, such as tiers and policies, share
+// a common prefix.  However, in order to support datastores that do not
+// support storing data at non-leaf nodes in the hierarchy (such as etcd v2),
+// the path returned for a "parent" key, such as a TierKey, is not a direct
+// ancestor of its children.
+//
+// For example, KeyToDefaultPath(TierKey{Tier: "a"}) returns
+//
+//     "/calico/v1/policy/tier/a/metadata"
+//
+// and KeyToDefaultPath(PolicyKey{Tier: "a", Name: "b"}) returns
+//
+//     "/calico/v1/policy/tier/a/policy/b"
+//
+// In this case, the common tier prefix is "/calico/v1/policy/tier/a".
+func KeyToDefaultPath(key Key) (string, error) {
+	return key.defaultPath()
+}
+
+// KeyToDefaultDeletePath converts one of the Keys from this package into a
+// unique '/'-delimited path, which is suitable for use as the key when
+// (recursively) deleting the value from a hierarchical (i.e. one with
+// directories and leaves) key/value datastore such as etcd v2.
+//
+// KeyToDefaultDeletePath returns a different path to KeyToDefaultPath when
+// it is a passed a Key that represents a non-leaf, such as a TierKey.  (A
+// tier has its own metadata but it also contains policies as children.)
+//
+// KeyToDefaultDeletePath returns the common prefix of the non-leaf key and
+// its children so that a recursive delete of that key would delete the
+// object itself and any children it has.
+//
+// For example, KeyToDefaultDeletePath(TierKey{Tier: "a"}) returns
+//
+//     "/calico/v1/policy/tier/a"
+//
+// which is a prefix of both KeyToDefaultPath(TierKey{Tier: "a"}):
+//
+//     "/calico/v1/policy/tier/a/metadata"
+//
+// and KeyToDefaultPath(PolicyKey{Tier: "a", Name: "b"}):
+//
+//     "/calico/v1/policy/tier/a/policy/b"
+func KeyToDefaultDeletePath(key Key) (string, error) {
+	return key.defaultDeletePath()
+}
+
+// ListOptionsToDefaultPathRoot converts list options struct into a
+// common-prefix path suitable for querying a datastore that uses the paths
+// returned by KeyToDefaultPath.  For example,
+//
+//     ListOptionsToDefaultPathRoot(TierListOptions{})
+//
+// doesn't specify any particular tier so it returns
+// "/calico/v1/policy/tier" which is a prefix for all tiers.  The datastore
+// must then do a recursive query to find all children of that path.
+// However,
+//
+//    ListOptionsToDefaultPathRoot(TierListOptions{Tier:"a"})
+//
+// returns a more-specific path, which filters down to the specific tier of
+// interest: "/calico/v1/policy/tier/a"
+func ListOptionsToDefaultPathRoot(listOptions ListInterface) string {
+	return listOptions.defaultPathRoot()
+}
+
+// KeyFromDefaultPath parses the default path representation of a key into one
+// of our <Type>Key structs.  Returns nil if the string doesn't match one of
+// our key types.
+func KeyFromDefaultPath(path string) Key {
+	glog.V(4).Infof("Parsing key %v", path)
+	if m := matchWorkloadEndpoint.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Workload endpoint")
 		return WorkloadEndpointKey{
 			Hostname:       m[1],
@@ -71,19 +143,19 @@ func ParseKey(key string) Key {
 			WorkloadID:     m[3],
 			EndpointID:     m[4],
 		}
-	} else if m := matchHostEndpoint.FindStringSubmatch(key); m != nil {
+	} else if m := matchHostEndpoint.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Host endpoint")
 		return HostEndpointKey{
 			Hostname:   m[1],
 			EndpointID: m[2],
 		}
-	} else if m := matchPolicy.FindStringSubmatch(key); m != nil {
+	} else if m := matchPolicy.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Policy")
 		return PolicyKey{
 			Tier: m[1],
 			Name: m[2],
 		}
-	} else if m := matchProfile.FindStringSubmatch(key); m != nil {
+	} else if m := matchProfile.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Profile %v", m)
 		pk := ProfileKey{m[1]}
 		switch m[2] {
@@ -98,13 +170,13 @@ func ParseKey(key string) Key {
 			return ProfileLabelsKey{ProfileKey: pk}
 		}
 		return nil
-	} else if m := matchTier.FindStringSubmatch(key); m != nil {
+	} else if m := matchTier.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Policy tier")
 		return TierKey{Name: m[1]}
-	} else if m := matchHostIp.FindStringSubmatch(key); m != nil {
+	} else if m := matchHostIp.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Host ID")
 		return HostIPKey{Hostname: m[1]}
-	} else if m := matchPool.FindStringSubmatch(key); m != nil {
+	} else if m := matchPool.FindStringSubmatch(path); m != nil {
 		glog.V(5).Infof("Pool")
 		mungedCIDR := m[1]
 		cidr := strings.Replace(mungedCIDR, "-", "/", 1)
@@ -113,17 +185,21 @@ func ParseKey(key string) Key {
 			panic(err)
 		}
 		return PoolKey{CIDR: *c}
-	} else if m := matchGlobalConfig.FindStringSubmatch(key); m != nil {
+	} else if m := matchGlobalConfig.FindStringSubmatch(path); m != nil {
 		return GlobalConfigKey{Name: m[1]}
-	} else if m := matchHostConfig.FindStringSubmatch(key); m != nil {
+	} else if m := matchHostConfig.FindStringSubmatch(path); m != nil {
 		return HostConfigKey{Hostname: m[1], Name: m[2]}
-	} else if matchReadyFlag.MatchString(key) {
+	} else if matchReadyFlag.MatchString(path) {
 		return ReadyFlagKey{}
 	}
 	// Not a key we know about.
 	return nil
 }
 
+// ParseValue parses the default JSON representation of our data into one of
+// our value structs, according to the type of key.  I.e. if passed a
+// PolicyKey as the first parameter, it will try to parse rawData into a
+// Policy struct.
 func ParseValue(key Key, rawData []byte) (interface{}, error) {
 	valueType := key.valueType()
 	if valueType == rawStringType {
@@ -151,13 +227,4 @@ func ParseValue(key Key, rawData []byte) (interface{}, error) {
 		iface = elem.Interface()
 	}
 	return iface, nil
-}
-
-func ParseKeyValue(key string, rawData []byte) (Key, interface{}, error) {
-	parsedKey := ParseKey(key)
-	if parsedKey == nil {
-		return nil, nil, errors.New("Failed to parse key")
-	}
-	value, err := ParseValue(parsedKey, rawData)
-	return parsedKey, value, err
 }

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -75,9 +75,9 @@ func (options PolicyListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options PolicyListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get Policy key from %s", ekey)
-	r := matchPolicy.FindAllStringSubmatch(ekey, -1)
+func (options PolicyListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get Policy key from %s", path)
+	r := matchPolicy.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil

--- a/lib/backend/model/policy.go
+++ b/lib/backend/model/policy.go
@@ -36,7 +36,7 @@ type PolicyKey struct {
 	Tier string `json:"-" validate:"required,name"`
 }
 
-func (key PolicyKey) DefaultPath() (string, error) {
+func (key PolicyKey) defaultPath() (string, error) {
 	if key.Tier == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "tier"}
 	}
@@ -48,8 +48,8 @@ func (key PolicyKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key PolicyKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key PolicyKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key PolicyKey) valueType() reflect.Type {
@@ -65,7 +65,7 @@ type PolicyListOptions struct {
 	Tier string
 }
 
-func (options PolicyListOptions) DefaultPathRoot() string {
+func (options PolicyListOptions) defaultPathRoot() string {
 	k := "/calico/v1/policy/tier"
 	k = k + fmt.Sprintf("/%s/policy", options.Tier)
 	if options.Name == "" {
@@ -75,7 +75,7 @@ func (options PolicyListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options PolicyListOptions) ParseDefaultKey(ekey string) Key {
+func (options PolicyListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get Policy key from %s", ekey)
 	r := matchPolicy.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/pool.go
+++ b/lib/backend/model/pool.go
@@ -70,11 +70,11 @@ func (options PoolListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options PoolListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get Pool key from %s", ekey)
-	r := matchPool.FindAllStringSubmatch(ekey, -1)
+func (options PoolListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get Pool key from %s", path)
+	r := matchPool.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
-		glog.V(2).Infof("%s didn't match regex", ekey)
+		glog.V(2).Infof("%s didn't match regex", path)
 		return nil
 	}
 	cidrStr := strings.Replace(r[0][1], "-", "/", 1)

--- a/lib/backend/model/pool.go
+++ b/lib/backend/model/pool.go
@@ -35,7 +35,7 @@ type PoolKey struct {
 	CIDR net.IPNet `json:"-" validate:"required,name"`
 }
 
-func (key PoolKey) DefaultPath() (string, error) {
+func (key PoolKey) defaultPath() (string, error) {
 	if key.CIDR.IP == nil {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "cidr"}
 	}
@@ -44,8 +44,8 @@ func (key PoolKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key PoolKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key PoolKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key PoolKey) valueType() reflect.Type {
@@ -60,7 +60,7 @@ type PoolListOptions struct {
 	CIDR net.IPNet
 }
 
-func (options PoolListOptions) DefaultPathRoot() string {
+func (options PoolListOptions) defaultPathRoot() string {
 	k := "/calico/v1/ipam/"
 	if options.CIDR.IP == nil {
 		return k
@@ -70,7 +70,7 @@ func (options PoolListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options PoolListOptions) ParseDefaultKey(ekey string) Key {
+func (options PoolListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get Pool key from %s", ekey)
 	r := matchPool.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -38,7 +38,7 @@ type ProfileKey struct {
 	Name string `json:"-" validate:"required,name"`
 }
 
-func (key ProfileKey) DefaultPath() (string, error) {
+func (key ProfileKey) defaultPath() (string, error) {
 	if key.Name == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
@@ -46,8 +46,8 @@ func (key ProfileKey) DefaultPath() (string, error) {
 	return e, nil
 }
 
-func (key ProfileKey) DefaultDeletePath() (string, error) {
-	return key.DefaultPath()
+func (key ProfileKey) defaultDeletePath() (string, error) {
+	return key.defaultPath()
 }
 
 func (key ProfileKey) valueType() reflect.Type {
@@ -63,8 +63,8 @@ type ProfileRulesKey struct {
 	ProfileKey
 }
 
-func (key ProfileRulesKey) DefaultPath() (string, error) {
-	e, err := key.ProfileKey.DefaultPath()
+func (key ProfileRulesKey) defaultPath() (string, error) {
+	e, err := key.ProfileKey.defaultPath()
 	return e + "/rules", err
 }
 
@@ -77,8 +77,8 @@ type ProfileTagsKey struct {
 	ProfileKey
 }
 
-func (key ProfileTagsKey) DefaultPath() (string, error) {
-	e, err := key.ProfileKey.DefaultPath()
+func (key ProfileTagsKey) defaultPath() (string, error) {
+	e, err := key.ProfileKey.defaultPath()
 	return e + "/tags", err
 }
 
@@ -91,8 +91,8 @@ type ProfileLabelsKey struct {
 	ProfileKey
 }
 
-func (key ProfileLabelsKey) DefaultPath() (string, error) {
-	e, err := key.ProfileKey.DefaultPath()
+func (key ProfileLabelsKey) defaultPath() (string, error) {
+	e, err := key.ProfileKey.defaultPath()
 	return e + "/labels", err
 }
 
@@ -104,7 +104,7 @@ type ProfileListOptions struct {
 	Name string
 }
 
-func (options ProfileListOptions) DefaultPathRoot() string {
+func (options ProfileListOptions) defaultPathRoot() string {
 	k := "/calico/v1/policy/profile"
 	if options.Name == "" {
 		return k
@@ -113,7 +113,7 @@ func (options ProfileListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options ProfileListOptions) ParseDefaultKey(ekey string) Key {
+func (options ProfileListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get Profile key from %s", ekey)
 	r := matchProfile.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/profile.go
+++ b/lib/backend/model/profile.go
@@ -113,9 +113,9 @@ func (options ProfileListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options ProfileListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get Profile key from %s", ekey)
-	r := matchProfile.FindAllStringSubmatch(ekey, -1)
+func (options ProfileListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get Profile key from %s", path)
+	r := matchProfile.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil

--- a/lib/backend/model/tier.go
+++ b/lib/backend/model/tier.go
@@ -67,9 +67,9 @@ func (options TierListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options TierListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get Tier key from %s", ekey)
-	r := matchTier.FindAllStringSubmatch(ekey, -1)
+func (options TierListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get Tier key from %s", path)
+	r := matchTier.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil

--- a/lib/backend/model/tier.go
+++ b/lib/backend/model/tier.go
@@ -33,12 +33,12 @@ type TierKey struct {
 	Name string `json:"-" validate:"required,name"`
 }
 
-func (key TierKey) DefaultPath() (string, error) {
-	k, err := key.DefaultDeletePath()
+func (key TierKey) defaultPath() (string, error) {
+	k, err := key.defaultDeletePath()
 	return k + "/metadata", err
 }
 
-func (key TierKey) DefaultDeletePath() (string, error) {
+func (key TierKey) defaultDeletePath() (string, error) {
 	if key.Name == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "name"}
 	}
@@ -58,7 +58,7 @@ type TierListOptions struct {
 	Name string
 }
 
-func (options TierListOptions) DefaultPathRoot() string {
+func (options TierListOptions) defaultPathRoot() string {
 	k := "/calico/v1/policy/tier"
 	if options.Name == "" {
 		return k
@@ -67,7 +67,7 @@ func (options TierListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options TierListOptions) ParseDefaultKey(ekey string) Key {
+func (options TierListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get Tier key from %s", ekey)
 	r := matchTier.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -109,9 +109,9 @@ func (options WorkloadEndpointListOptions) defaultPathRoot() string {
 	return k
 }
 
-func (options WorkloadEndpointListOptions) KeyFromDefaultPath(ekey string) Key {
-	glog.V(2).Infof("Get WorkloadEndpoint key from %s", ekey)
-	r := matchWorkloadEndpoint.FindAllStringSubmatch(ekey, -1)
+func (options WorkloadEndpointListOptions) KeyFromDefaultPath(path string) Key {
+	glog.V(2).Infof("Get WorkloadEndpoint key from %s", path)
+	r := matchWorkloadEndpoint.FindAllStringSubmatch(path, -1)
 	if len(r) != 1 {
 		glog.V(2).Infof("Didn't match regex")
 		return nil

--- a/lib/backend/model/workloadendpoint.go
+++ b/lib/backend/model/workloadendpoint.go
@@ -37,7 +37,7 @@ type WorkloadEndpointKey struct {
 	EndpointID     string `json:"-"`
 }
 
-func (key WorkloadEndpointKey) DefaultPath() (string, error) {
+func (key WorkloadEndpointKey) defaultPath() (string, error) {
 	if key.Hostname == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
 	}
@@ -54,7 +54,7 @@ func (key WorkloadEndpointKey) DefaultPath() (string, error) {
 		key.Hostname, key.OrchestratorID, key.WorkloadID, key.EndpointID), nil
 }
 
-func (key WorkloadEndpointKey) DefaultDeletePath() (string, error) {
+func (key WorkloadEndpointKey) defaultDeletePath() (string, error) {
 	if key.Hostname == "" {
 		return "", errors.ErrorInsufficientIdentifiers{Name: "hostname"}
 	}
@@ -88,7 +88,7 @@ type WorkloadEndpointListOptions struct {
 	EndpointID     string
 }
 
-func (options WorkloadEndpointListOptions) DefaultPathRoot() string {
+func (options WorkloadEndpointListOptions) defaultPathRoot() string {
 	k := "/calico/v1/host"
 	if options.Hostname == "" {
 		return k
@@ -109,7 +109,7 @@ func (options WorkloadEndpointListOptions) DefaultPathRoot() string {
 	return k
 }
 
-func (options WorkloadEndpointListOptions) ParseDefaultKey(ekey string) Key {
+func (options WorkloadEndpointListOptions) KeyFromDefaultPath(ekey string) Key {
 	glog.V(2).Infof("Get WorkloadEndpoint key from %s", ekey)
 	r := matchWorkloadEndpoint.FindAllStringSubmatch(ekey, -1)
 	if len(r) != 1 {

--- a/lib/hwm/hwm.go
+++ b/lib/hwm/hwm.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2016 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The hwm package contains the HighWatermarkTracker;
+package hwm
+
+import (
+	"github.com/golang/glog"
+	"gopkg.in/tchap/go-patricia.v2/patricia"
+)
+
+// HighWatermarkTracker: map that tracks the highest value seen for each key.
+// Supports temporary tracking of deletions in order to resolve concurrent updates.
+type HighWatermarkTracker struct {
+	hwms         *patricia.Trie
+	deletionHwms *patricia.Trie
+	deletionHwm  uint64
+}
+
+func NewHighWatermarkTracker() *HighWatermarkTracker {
+	trie := new(HighWatermarkTracker)
+	trie.hwms = patricia.NewTrie()
+	trie.deletionHwms = nil // No deletion tracking in progress
+	return trie
+}
+
+func (trie *HighWatermarkTracker) StartTrackingDeletions() {
+	trie.deletionHwms = patricia.NewTrie()
+	trie.deletionHwm = 0
+}
+
+func (trie *HighWatermarkTracker) StopTrackingDeletions() {
+	trie.deletionHwms = nil
+	trie.deletionHwm = 0
+}
+
+func (trie *HighWatermarkTracker) StoreUpdate(key string, newModIdx uint64) uint64 {
+	prefix := keyToPrefix(key)
+	if trie.deletionHwms != nil {
+		// Optimization: only check if this key is in the deletion
+		// trie if we've seen at least one deletion since...
+		if newModIdx < trie.deletionHwm {
+			_, delHwm := findLongestPrefix(trie.deletionHwms, prefix)
+			if delHwm != nil {
+				if newModIdx < delHwm.(uint64) {
+					return delHwm.(uint64)
+				}
+			}
+		}
+	}
+
+	// Get the old value
+	oldHwmOrNil := trie.hwms.Get(prefix)
+	if oldHwmOrNil != nil {
+		oldHwm := oldHwmOrNil.(uint64)
+		if oldHwm < newModIdx {
+			trie.hwms.Set(prefix, newModIdx)
+		}
+	} else {
+		trie.hwms.Set(prefix, newModIdx)
+	}
+	if oldHwmOrNil != nil {
+		return oldHwmOrNil.(uint64)
+	} else {
+		return 0
+	}
+}
+
+func (trie *HighWatermarkTracker) StoreDeletion(key string, newModIdx uint64) []string {
+	if newModIdx > trie.deletionHwm {
+		trie.deletionHwm = newModIdx
+	}
+	prefix := keyToPrefix(key)
+	if trie.deletionHwms != nil {
+		trie.deletionHwms.Set(prefix, newModIdx)
+	}
+	deletedKeys := make([]string, 0, 1)
+	trie.hwms.VisitSubtree(prefix, func(prefix patricia.Prefix, item patricia.Item) error {
+		childKey := prefixToKey(prefix)
+		deletedKeys = append(deletedKeys, childKey)
+		return nil
+	})
+	return deletedKeys
+}
+
+func (trie *HighWatermarkTracker) DeleteOldKeys(hwmLimit uint64) []string {
+	if trie.deletionHwms != nil {
+		panic("Deletion tracking not compatible with DeleteOldKeys")
+	}
+	deletedPrefixes := make([]patricia.Prefix, 0)
+	deletedKeys := make([]string, 0)
+	trie.hwms.Visit(func(prefix patricia.Prefix, item patricia.Item) error {
+		glog.V(4).Infof("Deleted prefix: %v", prefix)
+		if prefix == nil {
+			panic("nil prefix passed to visitor")
+		}
+		if item.(uint64) < hwmLimit {
+			prefixCopy := make(patricia.Prefix, len(prefix))
+			copy(prefixCopy, prefix)
+			deletedPrefixes = append(deletedPrefixes, prefixCopy)
+			deletedKeys = append(deletedKeys, prefixToKey(prefixCopy))
+		}
+		return nil
+	})
+	for ii, childPrefix := range deletedPrefixes {
+		glog.V(3).Infof("Key deleted, updating trie: %v", deletedKeys[ii])
+		trie.hwms.Delete(childPrefix)
+	}
+	return deletedKeys
+}
+
+func findLongestPrefix(trie *patricia.Trie, prefix patricia.Prefix) (patricia.Prefix, patricia.Item) {
+	var longestPrefix patricia.Prefix
+	var longestItem patricia.Item
+
+	trie.VisitPrefixes(prefix,
+		func(prefix patricia.Prefix, item patricia.Item) error {
+			if len(prefix) > len(longestPrefix) {
+				longestPrefix = prefix
+				longestItem = item
+			}
+			return nil
+		})
+	return longestPrefix, longestItem
+}
+
+// keyToPrefix converts a datastore key to a patricia.Prefix ending in a "/".
+// It's essential that our prefixes end with a "/" so that we can do deletion
+// processing.  Without a terminator, deleting "/foo" from the trie would
+// also delete "/foobar", which we don't want.
+func keyToPrefix(key string) patricia.Prefix {
+	if key[len(key)-1] != '/' {
+		key = key + "/"
+	}
+	return patricia.Prefix(key)
+}
+
+// prefixToKey converts a patricia.Prefix back into a datastore key.
+// Removed the trailing "/" added by encodeKey.
+func prefixToKey(prefix patricia.Prefix) string {
+	// Strip off the trailing "/"
+	return string(prefix)[:len(prefix)-1]
+}


### PR DESCRIPTION
To avoid conflicts, this builds on the PR to add the Syncer.  That should be merged first, or only the newer two commits reviewed.

This PR:

- Improves the backend docs.
- Replace DefaultPath/DefaultDeletePath with conversion functions.

The latter change 

- hides the fact that we use methods to implement the default path/delete path function behind a function-based interface
- prevents our Keys from "leaking" the path information out 
- gives a central choke point to impose new path guarantees and document them (such as adding a '/' onto the keys for etcdv3 compatibility)
- gives a place to document the paths more thoroughly, and it paves the way for adding more types of conversion function later.

One last wrinkle is that the ListInterface still declares a public method to parse the key, but only if it's of the correct type.  I propose that we just drop that method and use the generic `KeyFromDefaultPath` function, which is required for the `Syncer` and duplicates the functionality of the individual methods.  We'd still need to be able to filter the resulting keys but we could do that by, say, exposing the key type on the `ListInterface` or adding an `IsMatchingKey` method that checks the type of a given key.
