### PR TITLE
Document the northbound API

### DIFF
--- a/calicoctl/commands/apply.go
+++ b/calicoctl/commands/apply.go
@@ -25,6 +25,8 @@ func Apply(args []string) error {
 	doc := EtcdIntro + `Apply a resource by filename or stdin.  This creates a resource
 if it does not exist, and replaces a resource if it does exist.
 
+Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.
+
 Usage:
   calicoctl apply --filename=<FILENAME> [--config=<CONFIG>]
 

--- a/calicoctl/commands/create.go
+++ b/calicoctl/commands/create.go
@@ -24,6 +24,8 @@ import (
 func Create(args []string) error {
 	doc := EtcdIntro + `Create a resource by filename or stdin.
 
+Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.
+
 Usage:
   calicoctl create --filename=<FILENAME> [--skip-exists] [--config=<CONFIG>]
 

--- a/calicoctl/commands/replace.go
+++ b/calicoctl/commands/replace.go
@@ -25,6 +25,8 @@ import (
 func Replace(args []string) error {
 	doc := EtcdIntro + `Replace a resource by filename or stdin.
 
+Valid resource kinds are bgpPeer, hostEndpoint, policy, pool, profile and tier.
+
 If replacing an existing resource, the complete resource spec must be provided. This can be obtained by
 $ calicoctl get -o yaml <TYPE> <NAME>
 

--- a/docs/calicoctl/resources/bgppeer.md
+++ b/docs/calicoctl/resources/bgppeer.md
@@ -19,7 +19,6 @@ A BGP peer can also be added at the `node` scope, meaning only a single specifie
 apiVersion: v1
 kind: bgppeer
 metadata:
-  name: rack001-tor
   scope: node
   hostname: rack1-host1
   peerIP: 192.168.1.1
@@ -31,7 +30,6 @@ spec:
 #### Metadata
 | name     | description                                               | requirements                                                                     | schema |
 |----------|-----------------------------------------------------------|----------------------------------------------------------------------------------|--------|
-| name     | The name of this peer resource.                           |                                                                                  | string |
 | scope    | The scope of this peer.                                   | Accepted values: `global` or `node`                                              | string |
 | hostname | The hostname of the node that should peer with this peer. | Must be specified if scope is `node`, and must be omitted when scope is `global` | string |
 | peerIP   | The IP address of this peer.                              | Valid IPv4 or IPv6 address.                                                      | string |

--- a/docs/calicoctl/resources/hostendpoint.md
+++ b/docs/calicoctl/resources/hostendpoint.md
@@ -22,14 +22,15 @@ spec:
 
 ### Definitions
 #### Metadata
-| name     | description  | requirements                  | schema |
-|----------|--------------|-------------------------------|--------|
-| name     | The name of this hostEndpoint.               | string |
+| name     | description                                               | requirements                             | schema |
+|----------|-----------------------------------------------------------|------------------------------------------|--------|
+| name     | The name of this hostEndpoint.                            |                                          | string |
 | hostname | The hostname of the host where this hostEndpoint resides. | Required for `create`/`update`/`delete`. | string |
+| labels   | A set of labels to apply to this endpoint.                |      | Dictionary with key and values as strings. |
 
 #### Spec
 | name         | description                                              | requirements                | schema          |
 |--------------|----------------------------------------------------------|-----------------------------|-----------------|
-| interface    | The name of the interface to apply policy to.            |                             | string          |
+| interfaceName    | The name of the interface to apply policy to.            |                             | string          |
 | expectedIPs  | The expected IP addresses associated with the interface. | Valid IPv4 or IPv6 address. | list of strings |
 | profiles     | The list of profiles to apply to the endpoint.           |                             | list of strings |

--- a/docs/calicoctl/resources/policy.md
+++ b/docs/calicoctl/resources/policy.md
@@ -52,7 +52,7 @@ spec:
 | name | description  | requirements                  | schema |
 |------|--------------|-------------------------------|--------|
 | name | The name of the policy. | | string |
-| tier | The name of the parent tier. | If omitted, assumed to mean the "default" tier - which is automatically created by the calicoctl and is the last tier to be acted on. | string |
+| tier | The name of the parent tier. | If omitted, assumed to mean the "default" tier.  A "default" tier is automatically created if required, with default order (i.e. applied last) - the order of this tier may be modified after it is created. | string |
 
 
 #### PolicySpec

--- a/lib/api/bgppeer.go
+++ b/lib/api/bgppeer.go
@@ -15,35 +15,15 @@
 package api
 
 import (
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
-	. "github.com/tigera/libcalico-go/lib/net"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/net"
 	"github.com/tigera/libcalico-go/lib/scope"
 )
 
-type BGPPeerMetadata struct {
-	ObjectMetadata
-
-	// The scope of the peer.  This may be global or node.  A global peer is a
-	// BGP device that peers with all Calico nodes.  A node peer is a BGP device that
-	// peers with the specified Calico node (specified by the node hostname).
-	Scope scope.Scope `json:"scope" validate:"omitempty,scopeglobalornode"`
-
-	// The hostname of the node that is peering with this peer.  When modifying a
-	// BGP peer, the hostname must be specified when the scope is `node`, and must
-	// be omitted when the scope is `global`.
-	Hostname string `json:"hostname,omitempty" validate:"omitempty,name"`
-
-	// The IP address of the peer.
-	PeerIP IP `json:"peerIP" validate:"omitempty,ip"`
-}
-
-type BGPPeerSpec struct {
-	// The AS Number of the peer.
-	ASNumber int `json:"asNumber" validate:"required,asn"`
-}
-
+// BGPPeer contains information about a BGP peer resource that is a peer of a Calico
+// compute node.
 type BGPPeer struct {
-	TypeMetadata
+	unversioned.TypeMetadata
 
 	// Metadata for a BGPPeer.
 	Metadata BGPPeerMetadata `json:"metadata,omitempty"`
@@ -52,16 +32,56 @@ type BGPPeer struct {
 	Spec BGPPeerSpec `json:"spec,omitempty"`
 }
 
-func NewBGPPeer() *BGPPeer {
-	return &BGPPeer{TypeMetadata: TypeMetadata{Kind: "bgpPeer", APIVersion: "v1"}}
+// BGPPeerMetadata contains the metadata for a BGPPeer resource.
+type BGPPeerMetadata struct {
+	unversioned.ObjectMetadata
+
+	// The scope of the peer.  This may be global or node.  A global peer is a
+	// BGP device that peers with all Calico nodes.  A node peer is a BGP device that
+	// peers with the specified Calico node (specified by the node hostname).
+	Scope scope.Scope `json:"scope" validate:"omitempty,scopeglobalornode"`
+
+	// The hostname of the compute server that is peering with this peer.  When modifying a
+	// BGP peer, the hostname must be specified when the scope is `node`, and must
+	// be omitted when the scope is `global`.
+	Hostname string `json:"hostname,omitempty" validate:"omitempty,name"`
+
+	// The IP address of the peer.
+	PeerIP net.IP `json:"peerIP" validate:"omitempty,ip"`
 }
 
+// BGPPeerSpec contains the specification for a BGPPeer resource.
+type BGPPeerSpec struct {
+	// The AS Number of the peer.
+	ASNumber int `json:"asNumber" validate:"required,asn"`
+}
+
+// NewBGPPeer creates a new (zeroed) BGPPeer struct with the TypeMetadata initialised to the current
+// version.
+func NewBGPPeer() *BGPPeer {
+	return &BGPPeer{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind: "bgpPeer",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
+}
+
+// BGPPeerList contains a list of BGP Peer resources.  List types are returned from List()
+// enumerations in the client interface.
 type BGPPeerList struct {
-	TypeMetadata
-	Metadata ListMetadata `json:"metadata,omitempty"`
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
 	Items    []BGPPeer    `json:"items" validate:"dive"`
 }
 
+// NewBGPPeerList creates a new (zeroed) BGPPeerList struct with the TypeMetadata initialised to the current
+// version.
 func NewBGPPeerList() *BGPPeerList {
-	return &BGPPeerList{TypeMetadata: TypeMetadata{Kind: "bgpPeerList", APIVersion: "v1"}}
+	return &BGPPeerList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind: "bgpPeerList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }

--- a/lib/api/doc.go
+++ b/lib/api/doc.go
@@ -13,7 +13,21 @@
 // limitations under the License.
 
 /*
-Package api implements the resource struct definitions used by the northbound
-client API.
+Package api implements the struct definitions used on the northbound client API.
+
+In particular this includes:
+	-  The various resource types as exposed on the Northbound API.  The valid resource
+	   types are:
+		-  BGPPeer
+		-  HostEndpoint
+		-  Policy
+		-  Pool
+		-  Profile
+		-  Tier
+	-  The client configuration
+
+The resource structures include the JSON tags for each exposed field.  These are standard
+go-lang tags that define the JSON format of the structures as used by calicoctl.  The YAML
+format also used by calicoctl is directly mapped from the JSON.
 */
 package api

--- a/lib/api/hostendpoint.go
+++ b/lib/api/hostendpoint.go
@@ -15,39 +15,84 @@
 package api
 
 import (
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
-	. "github.com/tigera/libcalico-go/lib/net"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/net"
 )
 
-type HostEndpointMetadata struct {
-	ObjectMetadata
-	Name     string            `json:"name,omitempty" validate:"omitempty,name"`
-	Hostname string            `json:"hostname,omitempty" validate:"omitempty,name"`
-	Labels   map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
-}
-
-type HostEndpointSpec struct {
-	InterfaceName string   `json:"interfaceName,omitempty" validate:"omitempty,interface"`
-	ExpectedIPs   []IP     `json:"expectedIPs,omitempty" validate:"omitempty,dive,ip"`
-	Profiles      []string `json:"profiles,omitempty" validate:"omitempty,dive,name"`
-}
-
+// HostEndpoint contains information about a “bare-metal” interfaces attached to the host that is
+// running Calico’s agent, Felix. By default, Calico doesn’t apply any policy to such interfaces.
 type HostEndpoint struct {
-	TypeMetadata
+	unversioned.TypeMetadata
 	Metadata HostEndpointMetadata `json:"metadata,omitempty"`
 	Spec     HostEndpointSpec     `json:"spec,omitempty"`
 }
 
-func NewHostEndpoint() *HostEndpoint {
-	return &HostEndpoint{TypeMetadata: TypeMetadata{Kind: "hostEndpoint", APIVersion: "v1"}}
+// HostEndpointMetadata contains the Metadata for a HostEndpoint resource.
+type HostEndpointMetadata struct {
+	unversioned.ObjectMetadata
+
+	// The name of the endpoint.
+	Name     string            `json:"name,omitempty" validate:"omitempty,name"`
+
+	// The hostname of the compute server.
+	Hostname string            `json:"hostname,omitempty" validate:"omitempty,name"`
+
+	// The labels applied to the host endpoint.  It is expected that many endpoints share
+	// the same labels. For example, they could be used to label all “production” workloads
+	// with “deployment=prod” so that security policy can be applied to production workloads.
+	Labels   map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
 }
 
+// HostEndpointSpec contains the specification for a HostEndpoint resource.
+type HostEndpointSpec struct {
+	// The name of the linux interface to apply policy to; for example “eth0”.
+	// If "InterfaceName" is not present then at least one expected IP must be specified.
+	InterfaceName string   `json:"interfaceName,omitempty" validate:"omitempty,interface"`
+
+	// The expected IP addresses (IPv4 and IPv6) of the endpoint.
+	// If "InterfaceName" is not present, Calico will look for an interface matching any
+	// of the IPs in the list and apply policy to that.
+	//
+	// Note:
+	// 	When using the selector|tag match criteria in an ingress or egress security Policy
+	// 	or Profile, Calico converts the selector into a set of IP addresses. For host
+	// 	endpoints, the ExpectedIPs field is used for that purpose. (If only the interface
+	// 	name is specified, Calico does not learn the IPs of the interface for use in match
+	// 	criteria.)
+	ExpectedIPs   []net.IP     `json:"expectedIPs,omitempty" validate:"omitempty,dive,ip"`
+
+	// A list of identifiers of security Profile objects that apply to this endpoint. Each
+	// profile is applied in the order that they appear in this list.  Profile rules are applied
+	// after the tier security policy.
+	Profiles      []string `json:"profiles,omitempty" validate:"omitempty,dive,name"`
+}
+
+// NewHostEndpoint creates a new (zeroed) HostEndpoint struct with the TypeMetadata initialised to the current
+// version.
+func NewHostEndpoint() *HostEndpoint {
+	return &HostEndpoint{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind: "hostEndpoint",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
+}
+
+// HostEndpointList contains a list of Host Endpoint resources.  List types are returned from List()
+// enumerations in the client interface.
 type HostEndpointList struct {
-	TypeMetadata
-	Metadata ListMetadata   `json:"metadata,omitempty"`
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata   `json:"metadata,omitempty"`
 	Items    []HostEndpoint `json:"items" validate:"dive"`
 }
 
+// NewHostEndpoint creates a new (zeroed) HostEndpointList struct with the TypeMetadata initialised to the current
+// version.
 func NewHostEndpointList() *HostEndpointList {
-	return &HostEndpointList{TypeMetadata: TypeMetadata{Kind: "hostEndpointList", APIVersion: "v1"}}
+	return &HostEndpointList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind: "hostEndpointList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }

--- a/lib/api/policy.go
+++ b/lib/api/policy.go
@@ -15,38 +15,126 @@
 package api
 
 import (
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
 )
 
-type PolicyMetadata struct {
-	ObjectMetadata
-	Name string `json:"name,omitempty" validate:"omitempty,name"`
-	Tier string `json:"tier,omitempty" validate:"omitempty,name"`
-}
-
-type PolicySpec struct {
-	Order        *float32 `json:"order" validate:"order"`
-	IngressRules []Rule   `json:"ingress,omitempty" validate:"omitempty,dive"`
-	EgressRules  []Rule   `json:"egress,omitempty" validate:"omitempty,dive"`
-	Selector     string   `json:"selector" validate:"selector"`
-}
-
+// Policy contains information about a tiered security Policy resource.  This contains a set of
+// security rules to apply.  Security policies allow a tiered security model which can override the
+// security profiles directly referenced by an endpoint.
+//
+// Each policy must do one of the following:
+//
+//  	- Match the packet and apply a “next-tier” action; this skips the rest of the tier, deferring
+//        to the next tier (or the explicit profiles if this is the last tier.
+//  	- Match the packet and apply an “allow” action; this immediately accepts the packet, skipping
+//        all further tiers and profiles. This is not recommended in general, because it prevents
+//        further policy from being executed.
+// 	- Match the packet and apply a “deny” action; this drops the packet immediately, skipping all
+//        further tiers and profiles.
+// 	- Fail to match the packet; in which case the packet proceeds to the next policy in the tier.
+//        If there are no more policies in the tier then the packet is dropped.
+//
+// Note:
+// 	If no policies in a tier match an endpoint then the packet skips the tier completely. The
+// 	“default deny” behavior described above only applies if some of the policies in a tier match
+// 	the endpoint.
+//
+// Calico implements the security policy for each endpoint individually and only the policies that
+// have matching selectors are implemented. This ensures that the number of rules that actually need
+// to be inserted into the kernel is proportional to the number of local endpoints rather than the
+// total amount of policy. If no policies in a tier match a given endpoint then that tier is skipped.
 type Policy struct {
-	TypeMetadata
+	unversioned.TypeMetadata
 	Metadata PolicyMetadata `json:"metadata,omitempty"`
 	Spec     PolicySpec     `json:"spec,omitempty"`
 }
 
+// PolicyMetadata contains the metadata for a tiered security Policy resource.
+type PolicyMetadata struct {
+	unversioned.ObjectMetadata
+
+	// The name of the tiered security policy.
+	Name string `json:"name,omitempty" validate:"omitempty,name"`
+
+	// The name of the tier that this policy belongs to.  If this is omitted, the default
+	// tier (name is "default") is assumed.  The specified tier must exist in order to create
+	// security policies within the tier, the "default" tier is created automatically if it
+	// does not exist, this means for deployments requiring only a single Tier, the tier name
+	// may be omitted on all policy management requests.
+	Tier string `json:"tier,omitempty" validate:"omitempty,name"`
+}
+
+// PolicySpec contains the specification for a tiered security Policy resource.
+type PolicySpec struct {
+	// Order is an optional field that specifies the order in which the policy is applied
+	// within a given tier.  Policies with higher "order" are applied after those with lower
+	// order.  If the order is omitted, it may be considered to be "infinite" - i.e. the
+	// policy will be applied last.  Policies with identical order and within the same Tier
+	// will be applied in alphanumerical order based on the Policy "Name".
+	Order *float32 `json:"order,omitempty"`
+
+	// The ordered set of ingress rules.  Each rule contains a set of packet match criteria and
+	// a corresponding action to apply.
+	IngressRules []Rule `json:"ingress,omitempty" validate:"omitempty,dive"`
+
+	// The ordered set of egress rules.  Each rule contains a set of packet match criteria and
+	// a corresponding action to apply.
+	EgressRules []Rule `json:"egress,omitempty" validate:"omitempty,dive"`
+
+	// The selector is an expression used to pick pick out the endpoints that the policy should
+	// be applied to.
+	//
+	// Selector expressions follow this syntax:
+	//
+	// 	label == "string_literal"  ->  comparison, e.g. my_label == "foo bar"
+	// 	label != "string_literal"   ->  not equal; also matches if label is not present
+	// 	label in { "a", "b", "c", ... }  ->  true if the value of label X is one of "a", "b", "c"
+	// 	label not in { "a", "b", "c", ... }  ->  true if the value of label X is not one of "a", "b", "c"
+	// 	has(label_name)  -> True if that label is present
+	// 	! expr -> negation of expr
+	// 	expr && expr  -> Short-circuit and
+	// 	expr || expr  -> Short-circuit or
+	// 	( expr ) -> parens for grouping
+	// 	all() or the empty selector -> matches all endpoints.
+	//
+	// Label names are allowed to contain alphanumerics, -, _ and /. String literals are more permissive
+	// but they do not support escape characters.
+	//
+	// Examples (with made-up labels):
+	//
+	// 	type == "webserver" && deployment == "prod"
+	// 	type in {"frontend", "backend"}
+	// 	deployment != "dev"
+	// 	! has(label_name)
+	Selector string `json:"selector" validate:"selector"`
+}
+
+// NewPolicy creates a new (zeroed) Policy struct with the TypeMetadata initialised to the current
+// version.
 func NewPolicy() *Policy {
-	return &Policy{TypeMetadata: TypeMetadata{Kind: "policy", APIVersion: "v1"}}
+	return &Policy{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "policy",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }
 
+// PolicyList contains a list of tier security Policy resources.  List types are returned from List()
+// enumerations on the client interface.
 type PolicyList struct {
-	TypeMetadata
-	Metadata ListMetadata `json:"metadata,omitempty"`
-	Items    []Policy     `json:"items" validate:"dive"`
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
+	Items    []Policy                 `json:"items" validate:"dive"`
 }
 
+// NewPolicyList creates a new (zeroed) PolicyList struct with the TypeMetadata initialised to the current
+// version.
 func NewPolicyList() *PolicyList {
-	return &PolicyList{TypeMetadata: TypeMetadata{Kind: "policyList", APIVersion: "v1"}}
+	return &PolicyList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "policyList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }

--- a/lib/api/pool.go
+++ b/lib/api/pool.go
@@ -15,68 +15,85 @@
 package api
 
 import (
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
-	. "github.com/tigera/libcalico-go/lib/net"
-	. "github.com/tigera/libcalico-go/lib/validator"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/net"
+	cvalidator "github.com/tigera/libcalico-go/lib/validator"
 	"gopkg.in/go-playground/validator.v8"
 )
 
-type PoolMetadata struct {
-	ObjectMetadata
-	CIDR IPNet `json:"cidr"`
+// Pool contains the details of a Calico IP pool resource.
+// A pool resource is used by Calico in two ways:
+// 	- to provide a set of IP addresses from which Calico IPAM assigns addresses
+// 	  for workloads.
+// 	- to provide configuration specific to IP address range, such as configuration
+// 	  for the BGP daemon (e.g. when to use a GRE tunnel to encapsulate packets
+// 	  between compute hosts).
+type Pool struct {
+	unversioned.TypeMetadata
+	Metadata PoolMetadata `json:"metadata,omitempty"`
+	Spec     PoolSpec     `json:"spec,omitempty"`
 }
 
+// PoolMetadata contains the metadata for an IP pool resource.
+type PoolMetadata struct {
+	unversioned.ObjectMetadata
+	CIDR net.IPNet `json:"cidr"`
+}
+
+// PoolSpec contains the specification for an IP pool resource.
 type PoolSpec struct {
-	// Contains configuration for ipip tunneling
-	// for this pool. If not specified, then ipip
-	// tunneling is disabled for this pool.
+	// Contains configuration for ipip tunneling for this pool. If not specified,
+	// then ipip tunneling is disabled for this pool.
 	IPIP *IPIPConfiguration `json:"ipip,omitempty"`
 
-	// When nat-outgoing is true, packets sent from Calico networked
-	// containers in this pool to destinations outside of this pool
-	// will be masqueraded.
+	// When nat-outgoing is true, packets sent from Calico networked containers in
+	// this pool to destinations outside of this pool will be masqueraded.
 	NATOutgoing bool `json:"nat-outgoing,omitempty"`
 
-	// When disabled is true, Calico IPAM will not assign
-	// addreses from this pool.
+	// When disabled is true, Calico IPAM will not assign addresses from this pool.
 	Disabled bool `json:"disabled,omitempty"`
 }
 
 type IPIPConfiguration struct {
-	// When enabled is true, ipip tunneling will be
-	// used to deliver packets to destinations within this
-	// pool.
+	// When enabled is true, ipip tunneling will be used to deliver packets to
+	// destinations within this pool.
 	Enabled bool `json:"enabled,omitempty"`
 }
 
-type Pool struct {
-	TypeMetadata
-
-	// Metadata for a Pool.
-	Metadata PoolMetadata `json:"metadata,omitempty"`
-
-	// Specification for a Pool.
-	Spec PoolSpec `json:"spec,omitempty"`
-}
-
+// NewPool creates a new (zeroed) Pool struct with the TypeMetadata initialised to the current
+// version.
 func NewPool() *Pool {
-	return &Pool{TypeMetadata: TypeMetadata{Kind: "pool", APIVersion: "v1"}}
+	return &Pool{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "pool",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }
 
+// PoolList contains a list of IP pool resources.  List types are returned from List()
+// enumerations in the client interface.
 type PoolList struct {
-	TypeMetadata
-	Metadata ListMetadata `json:"metadata,omitempty"`
-	Items    []Pool       `json:"items" validate:"dive"`
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
+	Items    []Pool                   `json:"items" validate:"dive"`
 }
 
+// NewPool creates a new (zeroed) PoolList struct with the TypeMetadata initialised to the current
+// version.
 func NewPoolList() *PoolList {
-	return &PoolList{TypeMetadata: TypeMetadata{Kind: "poolList", APIVersion: "v1"}}
+	return &PoolList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "poolList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }
 
 // Register v1 structure validators to validate cross-field dependencies in any of the
 // required structures.
 func init() {
-	RegisterStructValidator(validatePool, Pool{})
+	cvalidator.RegisterStructValidator(validatePool, Pool{})
 }
 
 func validatePool(v *validator.Validate, structLevel *validator.StructLevel) {

--- a/lib/api/profile.go
+++ b/lib/api/profile.go
@@ -15,37 +15,74 @@
 package api
 
 import (
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
 )
 
-type ProfileMetadata struct {
-	ObjectMetadata
-	Name   string            `json:"name,omitempty" validate:"omitempty,name"`
-	Labels map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
-}
-
-type ProfileSpec struct {
-	IngressRules []Rule   `json:"ingress,omitempty" validate:"omitempty,dive"`
-	EgressRules  []Rule   `json:"egress,omitempty" validate:"omitempty,dive"`
-	Tags         []string `json:"tags,omitempty" validate:"omitempty,dive,tag"`
-}
-
+// Profile contains the details a security profile resource.  A profile is set of security rules
+// to apply on an endpoint.  An endpoint (either a host endpoint or an endpoint on a workload) can
+// reference zero or more profiles.  The profile rules are applied directly to the endpoint *after*
+// the tiered security policy has been applied, and in the order the profiles are declared on the
+// endpoint.
 type Profile struct {
-	TypeMetadata
+	unversioned.TypeMetadata
 	Metadata ProfileMetadata `json:"metadata,omitempty"`
 	Spec     ProfileSpec     `json:"spec,omitempty"`
 }
 
+// ProfileMetadata contains the metadata for a security Profile resource.
+type ProfileMetadata struct {
+	unversioned.ObjectMetadata
+
+	// The name of the endpoint.
+	Name string `json:"name,omitempty" validate:"omitempty,name"`
+
+	// The labels to apply to each endpoint that references this profile.  It is expected
+	// that many endpoints share the same labels. For example, they could be used to label all
+	// “production” workloads with “deployment=prod” so that security policy can be applied
+	// to production workloads.
+	Labels map[string]string `json:"labels,omitempty" validate:"omitempty,labels"`
+}
+
+// ProfileSpec contains the specification for a security Profile resource.
+type ProfileSpec struct {
+	// The ordered set of ingress rules.  Each rule contains a set of packet match criteria and
+	// a corresponding action to apply.
+	IngressRules []Rule `json:"ingress,omitempty" validate:"omitempty,dive"`
+
+	// The ordered set of egress rules.  Each rule contains a set of packet match criteria and
+	// a corresponding action to apply.
+	EgressRules []Rule `json:"egress,omitempty" validate:"omitempty,dive"`
+
+	// A list of tags that are applied to each endpoint that references this profile.
+	Tags []string `json:"tags,omitempty" validate:"omitempty,dive,tag"`
+}
+
+// NewProfile creates a new (zeroed) Profile struct with the TypeMetadata initialised to the current
+// version.
 func NewProfile() *Profile {
-	return &Profile{TypeMetadata: TypeMetadata{Kind: "profile", APIVersion: "v1"}}
+	return &Profile{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "profile",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }
 
+// A ProfileList contains a list of security Profile resources.  List types are returned from List()
+// enumerations on the client interface.
 type ProfileList struct {
-	TypeMetadata
-	Metadata ListMetadata `json:"metadata,omitempty"`
-	Items    []Profile    `json:"items" validate:"dive,omitempty"`
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
+	Items    []Profile                `json:"items" validate:"dive,omitempty"`
 }
 
+// NewProfile creates a new (zeroed) Profile struct with the TypeMetadata initialised to the current
+// version.
 func NewProfileList() *ProfileList {
-	return &ProfileList{TypeMetadata: TypeMetadata{Kind: "profileList", APIVersion: "v1"}}
+	return &ProfileList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "profileList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }

--- a/lib/api/rule.go
+++ b/lib/api/rule.go
@@ -23,34 +23,109 @@ import (
 	"gopkg.in/go-playground/validator.v8"
 )
 
+// A Rule encapsulates a set of match criteria and an action.  Both tiered security Policy
+// and security Profiles reference rules - separated out as a list of rules for both
+// ingress and egress packet matching.
+//
+// Each positive match criteria has a negated version, prefixed with ”Not”. All the match
+// criteria within a rule must be satisfied for a packet to match. A single rule can contain
+// the positive and negative version of a match and both must be satisfied for the rule to match.
 type Rule struct {
 	Action string `json:"action" validate:"action"`
 
+	// Protocol is an optional field that restricts the rule to only apply to traffic of
+	// a specific IP protocol. Required if any of the EntityRules contain Ports
+	// (because ports only apply to certain protocols).
+	//
+	// Must be one of these string values: "tcp", "udp", "icmp", "icmpv6", "sctp", "udplite"
+	// or an integer in the range 1-255.
 	Protocol *Protocol   `json:"protocol,omitempty" validate:"omitempty"`
+
+	// ICMP is an optional field that restricts the rule to apply to a specific type and
+	// code of ICMP traffic.  This should only be specified if the Protocol field is set to
+	// "icmp" or "icmpv6".
 	ICMP     *ICMPFields `json:"icmp,omitempty" validate:"omitempty"`
 
+	// NotProtocol is the negated version of the Protocol field.
 	NotProtocol *Protocol   `json:"!protocol,omitempty" validate:"omitempty"`
+
+	// NotICMP is the negated version of the ICMP field.
 	NotICMP     *ICMPFields `json:"!icmp,omitempty" validate:"omitempty"`
 
+	// Source contains the match criteria that apply to source entity.
 	Source      EntityRule `json:"source,omitempty" validate:"omitempty"`
+
+	// Destination contains the match criteria that apply to destination entity.
 	Destination EntityRule `json:"destination,omitempty" validate:"omitempty"`
 }
 
 // ICMPFields defines structure for ICMP and NotICMP sub-struct for ICMP code and type
 type ICMPFields struct {
-	Type *int `json:"type,omitempty" validate:"omitempty,gte=0,lte=255"`
+	// Match on a specific ICMP type.  For example a value of 8 refers to ICMP Echo Request
+	// (i.e. pings).
+	Type *int `json:"type,omitempty" validate:"omitempty,gte=0,lte=254"`
+
+	// Match on a specific ICMP code.  If specified, the Type value must also be specified.
+	// This is a technical limitation imposed by the kernel’s iptables firewall, which
+	// Calico uses to enforce the rule.
 	Code *int `json:"code,omitempty" validate:"omitempty,gte=0,lte=255"`
 }
 
+// An EntityRule is a sub-component of a Rule comprising the match criteria specific
+// to a particular entity (that is either the source or destination).
+//
+// A source EntityRule matches the source endpoint and originating traffic.
+// A desination EntityRule matches the destination endpoint and terminating traffic.
 type EntityRule struct {
+	// Tag is an optional field that restricts the rule to only apply to traffic that
+	// originates from (or terminates at) endpoints that have profiles with the given tag
+	// in them.
 	Tag      string `json:"tag,omitempty" validate:"omitempty,tag"`
+
+	// Net is an optional field that restricts the rule to only apply to traffic that
+	// originates from (or terminates at) IP addresses in the given subnet.
 	Net      *IPNet `json:"net,omitempty" validate:"omitempty"`
+
+	// Selector is an optional field that contains a selector expression (see Policy for
+	// sample syntax).  Only traffic that originates from (terminates at) endpoints matching
+	// the selector will be matched.
+	//
+	// Note that: in addition to the negated version of the Selector (see NotSelector below), the
+	// selector expression syntax itself supports negation.  The two types of negation are subtly
+	// different. One negates the set of matched endpoints, the other negates the whole match:
+	//
+	//	Selector = "!has(my_label)" matches packets that are from other Calico-controlled
+	// 	endpoints that do not have the label “my_label”.
+	//
+	// 	NotSelector = "has(my_label)" matches packets that are not from Calico-controlled
+	// 	endpoints that do have the label “my_label”.
+	//
+	// The effect is that the latter will accept packets from non-Calico sources whereas the
+	// former is limited to packets from Calico-controlled endpoints.
 	Selector string `json:"selector,omitempty" validate:"omitempty,selector"`
+
+	// Ports is an optional field that restricts the rule to only apply to traffic that has a
+	// source (destination) port that matches one of these ranges/values. This value is a
+	// list of integers or strings that represent ranges of ports.
+	//
+	// Since only some protocols have ports, if any ports are specified it requires the
+	// Protocol match in the Rule to be set to "tcp" or "udp".
 	Ports    []Port `json:"ports,omitempty" validate:"omitempty,dive"`
 
+	// NotTag is the negated version of the Tag field.
 	NotTag      string `json:"!tag,omitempty" validate:"omitempty,tag"`
+
+	// NotNet is the negated version of the Net field.
 	NotNet      *IPNet `json:"!net,omitempty" validate:"omitempty"`
+
+	// NotSelector is the negated version of the Selector field.  See Selector field for
+	// subtleties with negated selectors.
 	NotSelector string `json:"!selector,omitempty" validate:"omitempty,selector"`
+
+	// NotPorts is the negated version of the Ports field.
+	//
+	// Since only some protocols have ports, if any ports are specified it requires the
+	// Protocol match in the Rule to be set to "tcp" or "udp".
 	NotPorts    []Port `json:"!ports,omitempty" validate:"omitempty,dive"`
 }
 

--- a/lib/api/tier.go
+++ b/lib/api/tier.go
@@ -15,34 +15,62 @@
 package api
 
 import (
-	. "github.com/tigera/libcalico-go/lib/api/unversioned"
+	"github.com/tigera/libcalico-go/lib/api/unversioned"
 )
 
-type TierMetadata struct {
-	ObjectMetadata
-	Name string `json:"name,omitempty" validate:"omitempty,name"`
-}
-
-type TierSpec struct {
-	Order *float32 `json:"order,omitempty"`
-}
-
+// Tier contains the details of a security policy tier resource.  A tier contains a set of
+// policies that are applied to packets. Multiple tiers may be created and each tier is applied
+// in the order specified in the tier specification.
+//
+// See Policy for more information.
 type Tier struct {
-	TypeMetadata
+	unversioned.TypeMetadata
 	Metadata TierMetadata `json:"metadata,omitempty"`
 	Spec     TierSpec     `json:"spec,omitempty"`
 }
 
+// TierMetadata contains the metadata for a security policy Tier.
+type TierMetadata struct {
+	unversioned.ObjectMetadata
+	Name string `json:"name,omitempty" validate:"omitempty,name"`
+}
+
+// TierSpec contains the specification for a security policy Tier.
+type TierSpec struct {
+	// Order is an optional field that specifies the order in which the tier is applied.
+	// Tiers with higher "order" are applied after those with lower order.  If the order
+	// is omitted, it may be considered to be "infinite" - i.e. the tier will be applied
+	// last.  Tiers with identical order will be applied in alphanumerical order based
+	// on the Tier "Name".
+	Order *float32 `json:"order,omitempty"`
+}
+
+// NewTier creates a new (zeroed) Tier struct with the TypeMetadata initialised to the current
+// version.
 func NewTier() *Tier {
-	return &Tier{TypeMetadata: TypeMetadata{Kind: "tier", APIVersion: "v1"}}
+	return &Tier{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "tier",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }
 
+// A TierList contains a list of tier resources.  List types are returned from List()
+// enumerations in the client interface.
 type TierList struct {
-	TypeMetadata
-	Metadata ListMetadata `json:"metadata,omitempty"`
-	Items    []Tier       `json:"items" validate:"dive"`
+	unversioned.TypeMetadata
+	Metadata unversioned.ListMetadata `json:"metadata,omitempty"`
+	Items    []Tier                   `json:"items" validate:"dive"`
 }
 
+// NewTier creates a new (zeroed) Tier struct with the TypeMetadata initialised to the current
+// version.
 func NewTierList() *TierList {
-	return &TierList{TypeMetadata: TypeMetadata{Kind: "tierList", APIVersion: "v1"}}
+	return &TierList{
+		TypeMetadata: unversioned.TypeMetadata{
+			Kind:       "tierList",
+			APIVersion: unversioned.VersionCurrent,
+		},
+	}
 }

--- a/lib/api/unversioned/types.go
+++ b/lib/api/unversioned/types.go
@@ -19,12 +19,18 @@ type Resource interface {
 	GetTypeMetadata() TypeMetadata
 }
 
+// Define available versions.
+var (
+	Version_1_0 = "1.0"
+	VersionCurrent = Version_1_0
+)
+
 // ---- Type metadata ----
 //
 // All resource and resource lists embed a TypeMetadata as an anonymous field.
 type TypeMetadata struct {
-	Kind       string `json:"kind" validate:"required"`
-	APIVersion string `json:"apiVersion" validate:"required"`
+	Kind       string  `json:"kind" validate:"required"`
+	APIVersion string  `json:"apiVersion" validate:"required"`
 }
 
 func (md TypeMetadata) GetTypeMetadata() TypeMetadata {

--- a/lib/client/bgppeer.go
+++ b/lib/client/bgppeer.go
@@ -30,7 +30,7 @@ type BGPPeerInterface interface {
 	Delete(api.BGPPeerMetadata) error
 }
 
-// peers implements BGPPeerInterface
+// bgpPeers implements BGPPeerInterface
 type bgpPeers struct {
 	c *Client
 }

--- a/lib/client/doc.go
+++ b/lib/client/doc.go
@@ -14,5 +14,93 @@
 
 /*
 Package client implements the northbound client used to manage Calico configuration.
+
+This client is the main entry point for applications that are managing or querying
+Calico configuration.
+
+This client provides a typed interface for managing different resource types.  The
+definitions for each resource type are defined in the following package:
+	github.com/tigera/libcalico-go/lib/api
+
+The client has a number of methods that return interfaces for managing:
+	-  Tier resources
+	-  Policy resources
+	-  IP Pool resources
+	-  Host endpoint resources
+	-  Workload resources
+	-  Profile resources
+	-  IP Address Management
+
+See interface definitions for details about the set of management commands for each
+resource type.
+
+The resource management interfaces have a common set of commands to create, delete,
+update and retrieve resource instances.  For example, an application using this
+client to manage tier resources would create an instance of this client, create a
+new Tiers interface and call the appropriate methods on that interface.  For example:
+
+	// ClientConfig defaults to access an etcd backend datastore at
+	// localhost:2379.  For alternative access details, set the appropriate
+	// fields in the ClientConfig structure.
+	config := api.ClientConfig{}
+	client := New(&config)
+
+	// Obtain the interface for managing tier resources.
+	tiers := client.Tiers()
+
+	// Create a new tier.  All Create() methods return an error of type
+	// common.ErrorResourceAlreadyExists if the resource specified by its
+	// unique identifiers already exists.
+	tier, err := tiers.Create(&api.Tier{
+		Metadata: api.TierMetadata{
+			Name: "tier-1",
+		},
+		Spec: api.TierSpec{
+			Order: 100
+		},
+	}
+
+	// Update am existing tier.  All Update() methods return an error of type
+	// common.ErrorResourceDoesNotExist if the resource specified by its
+	// unique identifiers does not exist.
+	tier, err = tiers.Update(&api.Tier{
+		Metadata: api.TierMetadata{
+			Name: "tier-1",
+		},
+		Spec: api.TierSpec{
+			Order: 200
+		},
+	}
+
+	// Apply (update or create) a tier.  All Apply() methods will update a resource
+	// if it already exists, and will create a new resource if it does not.
+	tier, err = tiers.Apply(&api.Tier{
+		Metadata: api.TierMetadata{
+			Name: "tier-2",
+		},
+		Spec: api.TierSpec{
+			Order: 150
+		},
+	}
+
+	// Delete a tier.  All Delete() methods return an error of type
+	// common.ErrorResourceDoesNotExist if the resource specified by its
+	// unique identifiers does not exist.
+	tier, err = tiers.Delete(api.TierMetadata{
+		Name: "tier-2",
+	})
+
+	// Get a tier.  All Get() methods return an error of type
+	// common.ErrorResourceDoesNotExist if the resource specified by its
+	// unique identifiers does not exist.
+	tier, err = tiers.Get(api.TierMetadata{
+		Name: "tier-2",
+	})
+
+	// List all tiers.  All List() methods take a (sub-)set of the resource
+	// identifiers and return the corresponding list resource type that has an
+	// Items field containing a list of resources that match the supplied
+	// identifiers.
+	tierList, err := tiers.List(api.TierMetadata{})
 */
 package client


### PR DESCRIPTION
Add doc comments to all of the northbound structures and add the doc.go files for API and client.

Note that I have not added doc strings for the workload endpoints because it is likely that we will rework this to be a single workload object with a list of endpoints. That is WIP.