### PR TITLE
Fix 'make clean' in OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ run-etcd:
 
 .PHONY: clean
 clean:
-	find -name '*.coverprofile' -type f -delete
+	find . -name '*.coverprofile' -type f -delete
 	rm -rf bin \
 	       release \
 	       vendor


### PR DESCRIPTION
Use appropriate 'find' arguments to work with both GNU And BSD find
commands.